### PR TITLE
DB mock 및 subpath import 설정 수정

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -35,10 +35,19 @@ const config: StorybookConfig = {
 
     imageRule.exclude = /\.svg$/;
 
-    config.module?.rules?.push({
-      test: /\.svg$/,
-      use: ["@svgr/webpack"],
-    });
+    if (config.module?.rules) {
+      config.module.rules.push({
+        test: /\.svg$/,
+        use: ["@svgr/webpack"],
+      });
+    }
+
+    if (config.resolve) {
+      config.resolve.extensionAlias = {
+        ".js": [".ts", ".js"],
+        ".jsx": [".tsx", ".jsx"],
+      };
+    }
 
     return config;
   },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,8 +3,8 @@ import "./globals.css";
 import type { Metadata } from "next";
 import { Nanum_Gothic } from "next/font/google";
 
-import { PlatformStoreProvider } from "#lib/providers/PlatformStoreProvider";
-import Header from "#ui/Header/Header";
+import { PlatformStoreProvider } from "#lib/providers/PlatformStoreProvider.jsx";
+import Header from "#ui/Header/Header.jsx";
 
 const nanumGoth = Nanum_Gothic({ weight: ["400", "700"], subsets: ["latin"] });
 

--- a/app/lib/actions/createPostAction.ts
+++ b/app/lib/actions/createPostAction.ts
@@ -4,10 +4,10 @@ import { NoResultError } from "kysely";
 import { z } from "zod";
 
 import { auth } from "#auth";
-import { ERROR } from "#lib/constants/messages";
+import { ERROR } from "#lib/constants/messages.js";
 import { PLATFORM_ID } from "#lib/constants/platform";
 import { TAG_ID } from "#lib/constants/tag";
-import { createPost, type NewPostData } from "#lib/database/posts.js";
+import { createPost, type NewPostData } from "#lib/database/posts";
 import { ActionState } from "#lib/types/action";
 
 const baseSchema = z

--- a/app/lib/actions/createPostAction.ts
+++ b/app/lib/actions/createPostAction.ts
@@ -5,10 +5,10 @@ import { z } from "zod";
 
 import { auth } from "#auth";
 import { ERROR } from "#lib/constants/messages.js";
-import { PLATFORM_ID } from "#lib/constants/platform";
-import { TAG_ID } from "#lib/constants/tag";
+import { PLATFORM_ID } from "#lib/constants/platform.js";
+import { TAG_ID } from "#lib/constants/tag.js";
 import { createPost, type NewPostData } from "#lib/database/posts";
-import { ActionState } from "#lib/types/action";
+import type { ActionState } from "#lib/types/action.js";
 
 const baseSchema = z
   .object({

--- a/app/lib/actions/createPostAction.ts
+++ b/app/lib/actions/createPostAction.ts
@@ -7,7 +7,7 @@ import { auth } from "#auth";
 import { ERROR } from "#lib/constants/messages";
 import { PLATFORM_ID } from "#lib/constants/platform";
 import { TAG_ID } from "#lib/constants/tag";
-import { createPost, type NewPostData } from "#lib/database/posts";
+import { createPost, type NewPostData } from "#lib/database/posts.js";
 import { ActionState } from "#lib/types/action";
 
 const baseSchema = z
@@ -16,7 +16,7 @@ const baseSchema = z
     targetNickname: z.string().min(1, ERROR.NO_TARGET_NICKNAME),
     tag: z.nativeEnum(TAG_ID),
     content: z.string().min(30, ERROR.SHORT_CONTENT),
-    images: z.array(z.object({ url: z.string(), name: z.string() })).nullish(),
+    images: z.array(z.object({ id: z.string() })).nullish(),
     anonymousUserNickname: z.string().nullish(),
     etcPlatformName: z.string().nullish(),
   })
@@ -58,7 +58,7 @@ export async function createPostAction(
     platform: formData.get("platform"),
     targetNickname: formData.get("targetNickname"),
     tag: formData.get("tag"),
-    imageUrls: /*formData.get("imageUrls"),*/ [""],
+    images: formData.get("images"),
     content: formData.get("content"),
     anonymousUserNickname: formData.get("anonymousUserNickname"),
     etcPlatformName: formData.get("etcPlatformName"),
@@ -72,12 +72,15 @@ export async function createPostAction(
     };
   }
 
+  const { images, anonymousUserNickname, etcPlatformName, ...restData } =
+    input.data;
+
   const newPostData: NewPostData = {
     userId: session?.user?.id ?? null,
-    images: input.data.images ?? null,
-    anonymousUserNickname: input.data.anonymousUserNickname ?? null,
-    etcPlatformName: input.data.etcPlatformName ?? null,
-    ...input.data,
+    images: images?.map(({ id }) => id) ?? null,
+    anonymousUserNickname: anonymousUserNickname ?? null,
+    etcPlatformName: etcPlatformName ?? null,
+    ...restData,
   };
 
   try {

--- a/app/lib/actions/createPostAction.ts
+++ b/app/lib/actions/createPostAction.ts
@@ -7,7 +7,7 @@ import { auth } from "#auth";
 import { ERROR } from "#lib/constants/messages";
 import { PLATFORM_ID } from "#lib/constants/platform";
 import { TAG_ID } from "#lib/constants/tag";
-import { Database, getDB } from "#lib/database/db";
+import { createPost, type NewPostData } from "#lib/database/posts";
 import { ActionState } from "#lib/types/action";
 
 const baseSchema = z
@@ -32,7 +32,7 @@ const baseSchema = z
 
 export type FormValues = z.infer<typeof baseSchema>;
 
-export async function createPost(
+export async function createPostAction(
   prevState: ActionState,
   formData: FormData
 ): Promise<ActionState> {
@@ -72,10 +72,7 @@ export async function createPost(
     };
   }
 
-  const newPostData: Omit<
-    Database["Post"],
-    "id" | "status" | "createdAt" | "updatedAt"
-  > = {
+  const newPostData: NewPostData = {
     userId: session?.user?.id ?? null,
     images: input.data.images ?? null,
     anonymousUserNickname: input.data.anonymousUserNickname ?? null,
@@ -84,12 +81,7 @@ export async function createPost(
   };
 
   try {
-    const db = getDB();
-    var result = await db
-      .insertInto("Post")
-      .values(newPostData)
-      .returning("id")
-      .executeTakeFirstOrThrow();
+    var result = await createPost(newPostData);
   } catch (error) {
     console.error(error);
     if (error instanceof NoResultError) {

--- a/app/lib/constants/platform.ts
+++ b/app/lib/constants/platform.ts
@@ -1,4 +1,4 @@
-import { Platform } from "#lib/types/property";
+import type { Platform } from "#lib/types/property.js";
 
 export const PLATFORM_ID: { [key: number]: Platform } = [
   "daangn",

--- a/app/lib/constants/tag.ts
+++ b/app/lib/constants/tag.ts
@@ -1,4 +1,4 @@
-import { TagId } from "#lib/types/property";
+import { TagId } from "#lib/types/property.js";
 
 export const TAG_ID: { [key: number]: TagId } = [
   "abuse",

--- a/app/lib/database/db.mock.ts
+++ b/app/lib/database/db.mock.ts
@@ -1,6 +1,0 @@
-import { fn } from "@storybook/test";
-
-import * as actual from "./db";
-
-export const getDB = fn(actual.getDB).mockName("getDB");
-export const db = actual.db;

--- a/app/lib/database/db.ts
+++ b/app/lib/database/db.ts
@@ -67,5 +67,4 @@ export interface Database {
 }
 
 export const db = createKysely<Database>();
-export const getDB = () => db;
 export { sql } from "kysely";

--- a/app/lib/database/db.ts
+++ b/app/lib/database/db.ts
@@ -1,7 +1,7 @@
 import { createKysely } from "@vercel/postgres-kysely";
 import type { Generated, GeneratedAlways } from "kysely";
 
-import { Platform, PostCommentStatus } from "#lib/types/property";
+import type { Platform, PostCommentStatus } from "#lib/types/property.js";
 
 export interface Database {
   User: {

--- a/app/lib/database/db.ts
+++ b/app/lib/database/db.ts
@@ -42,12 +42,7 @@ export interface Database {
     platform: Platform;
     targetNickname: string;
     tag: string;
-    images:
-      | {
-          name: string;
-          url: string;
-        }[]
-      | null;
+    images: string[] | null;
     content: string;
     status: Generated<PostCommentStatus>;
     createdAt: GeneratedAlways<Date>;
@@ -59,11 +54,15 @@ export interface Database {
     id: GeneratedAlways<string>;
     userId: string;
     postId: string;
-    imageUrls: string[];
+    images: string[] | null;
     content: string;
     status: Generated<PostCommentStatus>;
     createdAt: GeneratedAlways<Date>;
     updatedAt: Generated<Date>;
+  };
+  Image: {
+    id: GeneratedAlways<string>;
+    url: string;
   };
 }
 

--- a/app/lib/database/posts.mock.ts
+++ b/app/lib/database/posts.mock.ts
@@ -1,0 +1,6 @@
+import { fn } from "@storybook/test";
+
+import * as actual from "./posts";
+
+export type NewPostData = actual.NewPostData;
+export const createPost = fn(actual.createPost).mockName("createPost");

--- a/app/lib/database/posts.ts
+++ b/app/lib/database/posts.ts
@@ -1,0 +1,14 @@
+import { Database, db } from "#lib/database/db";
+
+export type NewPostData = Omit<
+  Database["Post"],
+  "id" | "status" | "createdAt" | "updatedAt"
+>;
+
+export function createPost(newPostData: NewPostData) {
+  return db
+    .insertInto("Post")
+    .values(newPostData)
+    .returning("id")
+    .executeTakeFirstOrThrow();
+}

--- a/app/lib/database/posts.ts
+++ b/app/lib/database/posts.ts
@@ -1,4 +1,4 @@
-import { Database, db } from "#lib/database/db";
+import { type Database, db } from "#lib/database/db.js";
 
 export type NewPostData = Omit<
   Database["Post"],

--- a/app/lib/hooks/useCategoryItemList.ts
+++ b/app/lib/hooks/useCategoryItemList.ts
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 
-import { TRANS_DURATION } from "#lib/constants/platform";
-import { useCategoryStore } from "#lib/providers/CategoryStoreProvider";
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider";
-import { CategoryDirection, Platform } from "#lib/types/property";
+import { TRANS_DURATION } from "#lib/constants/platform.js";
+import { useCategoryStore } from "#lib/providers/CategoryStoreProvider.jsx";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import type { CategoryDirection, Platform } from "#lib/types/property.js";
 
 const directions: CategoryDirection[] = ["up", "down", "left", "up"];
 

--- a/app/lib/hooks/useFormAction.ts
+++ b/app/lib/hooks/useFormAction.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useFormState } from "react-dom";
 import { FieldValues, Path, useForm } from "react-hook-form";
 
-import { ActionState } from "#lib/types/action";
+import type { ActionState } from "#lib/types/action.js";
 
 export type OnSuccess = (
   state: Extract<ActionState, { status: "SUCCESS" }>

--- a/app/lib/hooks/useLastPlatform.ts
+++ b/app/lib/hooks/useLastPlatform.ts
@@ -2,8 +2,8 @@
 
 import { useRef, useState } from "react";
 
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider";
-import { Platform } from "#lib/types/property";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import type { Platform } from "#lib/types/property.js";
 
 function useLastPlatform(delay: number) {
   const [lastPlatform, setLastPlatform] = useState<Platform>("daangn");

--- a/app/lib/providers/CategoryStoreProvider.tsx
+++ b/app/lib/providers/CategoryStoreProvider.tsx
@@ -7,7 +7,7 @@ import {
   type CategoryStore,
   createCategoryStore,
   initCategoryStore,
-} from "#lib/stores/categoryStore";
+} from "#lib/stores/categoryStore.js";
 
 export const CategoryStoreContext =
   createContext<StoreApi<CategoryStore> | null>(null);

--- a/app/lib/providers/PlatformStoreProvider.tsx
+++ b/app/lib/providers/PlatformStoreProvider.tsx
@@ -7,8 +7,8 @@ import {
   createPlatformStore,
   initPlatformStore,
   type PlatformStore,
-} from "#lib/stores/platformStore";
-import { Platform } from "#lib/types/property";
+} from "#lib/stores/platformStore.js";
+import type { Platform } from "#lib/types/property.js";
 
 export const PlatformStoreContext =
   createContext<StoreApi<PlatformStore> | null>(null);

--- a/app/lib/providers/SearchStoreProvider.tsx
+++ b/app/lib/providers/SearchStoreProvider.tsx
@@ -7,7 +7,7 @@ import {
   createSearchStore,
   initSearchStore,
   type SearchStore,
-} from "#lib/stores/searchStore";
+} from "#lib/stores/searchStore.js";
 
 export const SearchStoreContext = createContext<StoreApi<SearchStore> | null>(
   null

--- a/app/lib/stores/categoryStore.ts
+++ b/app/lib/stores/categoryStore.ts
@@ -1,6 +1,6 @@
 import { createStore } from "zustand/vanilla";
 
-import { CategoryDirection } from "#lib/types/property";
+import type { CategoryDirection } from "#lib/types/property.js";
 
 export type CategoryState = {
   direction: CategoryDirection;

--- a/app/lib/stores/platformStore.ts
+++ b/app/lib/stores/platformStore.ts
@@ -1,6 +1,6 @@
 import { createStore } from "zustand/vanilla";
 
-import { Platform } from "#lib/types/property";
+import type { Platform } from "#lib/types/property.js";
 
 export type PlatformState = {
   platform: Platform;

--- a/app/lib/stores/searchStore.ts
+++ b/app/lib/stores/searchStore.ts
@@ -1,6 +1,6 @@
 import { createStore } from "zustand/vanilla";
 
-import { TroublemakerInfo } from "#lib/types/response";
+import type { TroublemakerInfo } from "#lib/types/response.js";
 
 export type SearchState = {
   query: string;

--- a/app/lib/types/action.ts
+++ b/app/lib/types/action.ts
@@ -1,4 +1,4 @@
-import { FormValues } from "#lib/actions/createPostAction";
+import type { FormValues } from "#lib/actions/createPostAction.js";
 
 export type ActionState =
   | {

--- a/app/lib/types/response.ts
+++ b/app/lib/types/response.ts
@@ -1,4 +1,4 @@
-import { Platform } from "#lib/types/property";
+import type { Platform } from "#lib/types/property.js";
 
 export type TroublemakerInfo = {
   id: number;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
-import Banner from "#ui/Banner/Banner";
-import CreateButton from "#ui/Button/CreateButton";
-import Search from "#ui/Search/Search";
+import Banner from "#ui/Banner/Banner.jsx";
+import CreateButton from "#ui/Button/CreateButton.jsx";
+import Search from "#ui/Search/Search.jsx";
 
 export default function Home() {
   return (

--- a/app/post/create/form.tsx
+++ b/app/post/create/form.tsx
@@ -6,7 +6,7 @@ import { Session } from "next-auth";
 import { ChangeEvent, useCallback, useState } from "react";
 import { Controller, useFieldArray } from "react-hook-form";
 
-import { createPost, FormValues } from "#lib/actions/createPostAction";
+import { createPostAction, FormValues } from "#lib/actions/createPostAction";
 import { PLATFORM_NAME } from "#lib/constants/platform";
 import { TAG_DESC, TAG_NAMES } from "#lib/constants/tag";
 import { OnSuccess, useFormAction } from "#lib/hooks/useFormAction";
@@ -52,7 +52,7 @@ function PostCreateForm({ session }: PostCreateFormProps) {
     control,
     formState: { errors },
     formAction,
-  } = useFormAction<FormValues>({ action: createPost, onSuccess });
+  } = useFormAction<FormValues>({ action: createPostAction, onSuccess });
   const { fields, append, remove } = useFieldArray<FormValues>({
     control,
     name: "images",

--- a/app/post/create/form.tsx
+++ b/app/post/create/form.tsx
@@ -154,8 +154,7 @@ function PostCreateForm({ session }: PostCreateFormProps) {
           <ul>
             {fields.map((item, index) => (
               <li key={item.id}>
-                <Input type="hidden" {...register(`images.${index}.name`)} />
-                <Input type="hidden" {...register(`images.${index}.url`)} />
+                <Input type="hidden" {...register(`images.${index}.id`)} />
               </li>
             ))}
           </ul>

--- a/app/post/create/form.tsx
+++ b/app/post/create/form.tsx
@@ -10,13 +10,13 @@ import {
   createPostAction,
   type FormValues,
 } from "#lib/actions/createPostAction.js";
-import { PLATFORM_NAME } from "#lib/constants/platform";
-import { TAG_DESC, TAG_NAMES } from "#lib/constants/tag";
-import { OnSuccess, useFormAction } from "#lib/hooks/useFormAction";
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider";
-import { Platform, TagId } from "#lib/types/property";
+import { PLATFORM_NAME } from "#lib/constants/platform.js";
+import { TAG_DESC, TAG_NAMES } from "#lib/constants/tag.js";
+import { type OnSuccess, useFormAction } from "#lib/hooks/useFormAction.js";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import type { Platform, TagId } from "#lib/types/property.js";
 import Logo from "#public/당근빳다.svg";
-import Button from "#ui/Button/Button";
+import Button from "#ui/Button/Button.jsx";
 import CancelButton from "#ui/Button/CancelButton.jsx";
 import {
   ErrorText,
@@ -26,8 +26,8 @@ import {
   RadioTabs,
   Select,
   SubmitButton,
-  Textarea,
-} from "#ui/formItems/index";
+} from "#ui/formItems/index.jsx";
+import Textarea from "#ui/formItems/Textarea.jsx";
 
 const platformOptions = Object.entries(PLATFORM_NAME).map(([id, name]) => ({
   name,

--- a/app/post/create/form.tsx
+++ b/app/post/create/form.tsx
@@ -6,7 +6,10 @@ import { Session } from "next-auth";
 import { ChangeEvent, useCallback, useState } from "react";
 import { Controller, useFieldArray } from "react-hook-form";
 
-import { createPostAction, FormValues } from "#lib/actions/createPostAction";
+import {
+  createPostAction,
+  type FormValues,
+} from "#lib/actions/createPostAction.js";
 import { PLATFORM_NAME } from "#lib/constants/platform";
 import { TAG_DESC, TAG_NAMES } from "#lib/constants/tag";
 import { OnSuccess, useFormAction } from "#lib/hooks/useFormAction";
@@ -14,7 +17,7 @@ import { usePlatformStore } from "#lib/providers/PlatformStoreProvider";
 import { Platform, TagId } from "#lib/types/property";
 import Logo from "#public/당근빳다.svg";
 import Button from "#ui/Button/Button";
-import CancelButton from "#ui/Button/CancelButton";
+import CancelButton from "#ui/Button/CancelButton.jsx";
 import {
   ErrorText,
   Input,

--- a/app/post/create/page.tsx
+++ b/app/post/create/page.tsx
@@ -1,4 +1,4 @@
-import PostCreateForm from "#app/post/create/form";
+import PostCreateForm from "#app/post/create/form.jsx";
 import { auth } from "#auth";
 
 async function PostCreatePage() {

--- a/app/ui/Banner/Banner.tsx
+++ b/app/ui/Banner/Banner.tsx
@@ -2,9 +2,9 @@
 
 import { HTMLAttributes, useEffect, useRef, useState } from "react";
 
-import { BANNER_IMAGES } from "#lib/constants/banner";
-import ImageContainer from "#ui/Banner/ImageContainer";
-import SliderButton from "#ui/Banner/SliderButton";
+import { BANNER_IMAGES } from "#lib/constants/banner.js";
+import ImageContainer from "#ui/Banner/ImageContainer.jsx";
+import SliderButton from "#ui/Banner/SliderButton.jsx";
 
 function Banner({ className = "", ...props }: HTMLAttributes<HTMLDivElement>) {
   const [curImage, setCurImage] = useState(0);

--- a/app/ui/Banner/ImageContainer.tsx
+++ b/app/ui/Banner/ImageContainer.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import { HTMLAttributes } from "react";
 
-import { BANNER_IMAGES } from "#lib/constants/banner";
+import { BANNER_IMAGES } from "#lib/constants/banner.js";
 
 function ImageContainer({
   className = "",

--- a/app/ui/Banner/SliderButton.tsx
+++ b/app/ui/Banner/SliderButton.tsx
@@ -2,7 +2,7 @@
 
 import { Dispatch, HTMLAttributes, MouseEvent, SetStateAction } from "react";
 
-import { BANNER_IMAGES } from "#lib/constants/banner";
+import { BANNER_IMAGES } from "#lib/constants/banner.js";
 
 interface SliderButtonProps extends HTMLAttributes<HTMLDivElement> {
   curImage: number;

--- a/app/ui/Button/Button.tsx
+++ b/app/ui/Button/Button.tsx
@@ -3,8 +3,8 @@
 import { Button as HeadlessButton } from "@headlessui/react";
 import { ButtonHTMLAttributes, PropsWithChildren } from "react";
 
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider";
-import { Platform } from "#lib/types/property";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import type { Platform } from "#lib/types/property.js";
 import Logo from "#public/당근빳다.svg";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {

--- a/app/ui/Button/CreateButton.tsx
+++ b/app/ui/Button/CreateButton.tsx
@@ -3,8 +3,8 @@
 import { BiPlus } from "@react-icons/all-files/bi/BiPlus";
 import Link from "next/link";
 
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider";
-import { Platform } from "#lib/types/property";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import type { Platform } from "#lib/types/property.js";
 
 interface CreateButtonProps {
   classname?: string;

--- a/app/ui/Header/Header.tsx
+++ b/app/ui/Header/Header.tsx
@@ -1,10 +1,10 @@
 import Link from "next/link";
 
 import Logo from "#public/당근빳다.svg";
-import HeaderSearch from "#ui/Header/HeaderSearch";
-import LogoText from "#ui/Header/LogoText";
-import PostCreateButton from "#ui/Header/PostCreateButton";
-import ProfileMenu from "#ui/Header/Profile/ProfileMenu";
+import HeaderSearch from "#ui/Header/HeaderSearch.jsx";
+import LogoText from "#ui/Header/LogoText.jsx";
+import PostCreateButton from "#ui/Header/PostCreateButton.jsx";
+import ProfileMenu from "#ui/Header/Profile/ProfileMenu.jsx";
 
 function Header() {
   return (

--- a/app/ui/Header/HeaderSearch.tsx
+++ b/app/ui/Header/HeaderSearch.tsx
@@ -11,9 +11,9 @@ import {
 import { usePathname } from "next/navigation";
 import { MouseEvent } from "react";
 
-import { SearchStoreProvider } from "#lib/providers/SearchStoreProvider";
-import SearchBar from "#ui/SearchBar/SearchBar";
-import SearchList from "#ui/SearchList/SearchList";
+import { SearchStoreProvider } from "#lib/providers/SearchStoreProvider.jsx";
+import SearchBar from "#ui/SearchBar/SearchBar.jsx";
+import SearchList from "#ui/SearchList/SearchList.jsx";
 
 interface HeaderSearchProps extends PopoverProps {}
 

--- a/app/ui/Header/PostCreateButton.tsx
+++ b/app/ui/Header/PostCreateButton.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-import Button from "#ui/Button/Button";
+import Button from "#ui/Button/Button.jsx";
 
 function PostCreateButton() {
   const pathname = usePathname();

--- a/app/ui/Header/Profile/ProfileDropdown.tsx
+++ b/app/ui/Header/Profile/ProfileDropdown.tsx
@@ -5,8 +5,8 @@ import { Session } from "next-auth";
 import { forwardRef } from "react";
 
 import { providerMap } from "#auth";
-import MenuItemButton from "#ui/Header/Profile/MenuItemButton";
-import SignButton from "#ui/Header/Profile/SignButton";
+import MenuItemButton from "#ui/Header/Profile/MenuItemButton.jsx";
+import SignButton from "#ui/Header/Profile/SignButton.jsx";
 
 interface ProfileDropdownProps {
   session: Session | null;

--- a/app/ui/Header/Profile/ProfileMenu.tsx
+++ b/app/ui/Header/Profile/ProfileMenu.tsx
@@ -1,8 +1,8 @@
 import { Menu, Transition } from "@headlessui/react";
 
 import { auth } from "#auth";
-import ProfileDropdown from "#ui/Header/Profile/ProfileDropdown";
-import ProfileMenuButton from "#ui/Header/Profile/ProfileMenuButton";
+import ProfileDropdown from "#ui/Header/Profile/ProfileDropdown.jsx";
+import ProfileMenuButton from "#ui/Header/Profile/ProfileMenuButton.jsx";
 
 async function ProfileMenu() {
   const session = await auth();

--- a/app/ui/Header/Profile/SignButton.tsx
+++ b/app/ui/Header/Profile/SignButton.tsx
@@ -4,7 +4,7 @@ import { signIn, signOut } from "#auth";
 import GoogleLogo from "#public/google.svg";
 import KakaoLogo from "#public/kakao.svg";
 import NaverLogo from "#public/naver.svg";
-import MenuItemButton from "#ui/Header/Profile/MenuItemButton";
+import MenuItemButton from "#ui/Header/Profile/MenuItemButton.jsx";
 
 interface SignButtonProps {
   providerData?: { id: string; name: string };

--- a/app/ui/Search/Search.tsx
+++ b/app/ui/Search/Search.tsx
@@ -1,8 +1,8 @@
 import { HTMLAttributes } from "react";
 
-import { SearchStoreProvider } from "#lib/providers/SearchStoreProvider";
-import SearchBar from "#ui/SearchBar/SearchBar";
-import SearchList from "#ui/SearchList/SearchList";
+import { SearchStoreProvider } from "#lib/providers/SearchStoreProvider.jsx";
+import SearchBar from "#ui/SearchBar/SearchBar.jsx";
+import SearchList from "#ui/SearchList/SearchList.jsx";
 
 interface SearchProps extends HTMLAttributes<HTMLDivElement> {}
 

--- a/app/ui/SearchBar/Category.tsx
+++ b/app/ui/SearchBar/Category.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { PLATFORM_NAME, TRANS_DURATION } from "#lib/constants/platform";
-import useLastPlatform from "#lib/hooks/useLastPlatform";
-import { useCategoryStore } from "#lib/providers/CategoryStoreProvider";
-import { CategoryDirection, Platform } from "#lib/types/property";
+import { PLATFORM_NAME, TRANS_DURATION } from "#lib/constants/platform.js";
+import useLastPlatform from "#lib/hooks/useLastPlatform.js";
+import { useCategoryStore } from "#lib/providers/CategoryStoreProvider.jsx";
+import type { CategoryDirection, Platform } from "#lib/types/property.js";
 
 function Category() {
   const { lastPlatform, platform, isChanging } =

--- a/app/ui/SearchBar/CategoryDivider.tsx
+++ b/app/ui/SearchBar/CategoryDivider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider";
-import { Platform } from "#lib/types/property";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import type { Platform } from "#lib/types/property.js";
 
 function CategoryDivider() {
   const platform = usePlatformStore((state) => state.platform);

--- a/app/ui/SearchBar/CategoryItem.tsx
+++ b/app/ui/SearchBar/CategoryItem.tsx
@@ -1,7 +1,7 @@
 import { FiMoreHorizontal } from "@react-icons/all-files/fi/FiMoreHorizontal";
 
-import { PLATFORM_NAME } from "#lib/constants/platform";
-import { Platform } from "#lib/types/property";
+import { PLATFORM_NAME } from "#lib/constants/platform.js";
+import type { Platform } from "#lib/types/property.js";
 import DaangnLogo from "#public/당근.svg";
 import BunjangLogo from "#public/번개장터.svg";
 import JoongnaLogo from "#public/중고나라.svg";

--- a/app/ui/SearchBar/CategorySelector.tsx
+++ b/app/ui/SearchBar/CategorySelector.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { PLATFORM_NAME, TRANS_DURATION } from "#lib/constants/platform";
-import useCategoryItemList from "#lib/hooks/useCategoryItemList";
-import useToggleChildrenStyle from "#lib/hooks/useToggleChildrenStyle";
-import { useCategoryStore } from "#lib/providers/CategoryStoreProvider";
-import CategoryItem from "#ui/SearchBar/CategoryItem";
+import { PLATFORM_NAME, TRANS_DURATION } from "#lib/constants/platform.js";
+import useCategoryItemList from "#lib/hooks/useCategoryItemList.js";
+import useToggleChildrenStyle from "#lib/hooks/useToggleChildrenStyle.js";
+import { useCategoryStore } from "#lib/providers/CategoryStoreProvider.jsx";
+import CategoryItem from "#ui/SearchBar/CategoryItem.jsx";
 
 function CategorySelector() {
   const isActive = useCategoryStore((state) => state.isActive);

--- a/app/ui/SearchBar/SearchBar.tsx
+++ b/app/ui/SearchBar/SearchBar.tsx
@@ -1,11 +1,11 @@
 import { forwardRef, HTMLAttributes } from "react";
 
-import { CategoryStoreProvider } from "#lib/providers/CategoryStoreProvider";
-import Category from "#ui/SearchBar/Category";
-import CategoryDivider from "#ui/SearchBar/CategoryDivider";
-import CategorySelector from "#ui/SearchBar/CategorySelector";
-import SearchBarCore from "#ui/SearchBar/SearchBarCore";
-import SearchBarWrapper from "#ui/SearchBar/SearchBarWrapper";
+import { CategoryStoreProvider } from "#lib/providers/CategoryStoreProvider.jsx";
+import Category from "#ui/SearchBar/Category.jsx";
+import CategoryDivider from "#ui/SearchBar/CategoryDivider.jsx";
+import CategorySelector from "#ui/SearchBar/CategorySelector.jsx";
+import SearchBarCore from "#ui/SearchBar/SearchBarCore.jsx";
+import SearchBarWrapper from "#ui/SearchBar/SearchBarWrapper.jsx";
 
 interface SearchBarProps extends HTMLAttributes<HTMLDivElement> {}
 

--- a/app/ui/SearchBar/SearchBarCore.tsx
+++ b/app/ui/SearchBar/SearchBarCore.tsx
@@ -2,9 +2,9 @@
 
 import { IoSearchOutline } from "@react-icons/all-files/io5/IoSearchOutline";
 
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider";
-import { useSearchStore } from "#lib/providers/SearchStoreProvider";
-import { Platform } from "#lib/types/property";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import { useSearchStore } from "#lib/providers/SearchStoreProvider.jsx";
+import type { Platform } from "#lib/types/property.js";
 
 function SearchBarCore() {
   const { query, updateQuery } = useSearchStore((state) => state);

--- a/app/ui/SearchBar/SearchBarWrapper.tsx
+++ b/app/ui/SearchBar/SearchBarWrapper.tsx
@@ -2,8 +2,8 @@
 
 import { PropsWithChildren } from "react";
 
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider";
-import { Platform } from "#lib/types/property";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import type { Platform } from "#lib/types/property.js";
 
 function SearchBarWrapper({ children }: PropsWithChildren) {
   const platform = usePlatformStore((state) => state.platform);

--- a/app/ui/SearchList/SearchList.tsx
+++ b/app/ui/SearchList/SearchList.tsx
@@ -2,11 +2,11 @@
 
 import { Fragment, HTMLAttributes } from "react";
 
-import { useSearchStore } from "#lib/providers/SearchStoreProvider";
-import { TroublemakerInfo } from "#lib/types/response";
-import Divider from "#ui/Divider/Divider";
-import NoResults from "#ui/SearchList/NoResults";
-import SearchListItem from "#ui/SearchList/SearchListItem";
+import { useSearchStore } from "#lib/providers/SearchStoreProvider.jsx";
+import type { TroublemakerInfo } from "#lib/types/response.js";
+import Divider from "#ui/Divider/Divider.jsx";
+import NoResults from "#ui/SearchList/NoResults.jsx";
+import SearchListItem from "#ui/SearchList/SearchListItem.jsx";
 
 const tempList: TroublemakerInfo[] = [
   {

--- a/app/ui/SearchList/SearchListItem.tsx
+++ b/app/ui/SearchList/SearchListItem.tsx
@@ -1,8 +1,8 @@
 import Link from "next/link";
 
-import { Platform } from "#lib/types/property";
-import { TroublemakerInfo } from "#lib/types/response";
-import Thumbnail from "#ui/Thumbnail/Thumbnail";
+import type { Platform } from "#lib/types/property.js";
+import type { TroublemakerInfo } from "#lib/types/response.js";
+import Thumbnail from "#ui/Thumbnail/Thumbnail.jsx";
 
 interface SearchListItemProps {
   itemInfo: TroublemakerInfo;

--- a/app/ui/Thumbnail/Thumbnail.tsx
+++ b/app/ui/Thumbnail/Thumbnail.tsx
@@ -4,7 +4,7 @@ import { FiMoreHorizontal } from "@react-icons/all-files/fi/FiMoreHorizontal";
 import Image, { ImageProps } from "next/image";
 import { useState } from "react";
 
-import { Platform } from "#lib/types/property";
+import type { Platform } from "#lib/types/property.js";
 import DaangnLogo from "#public/당근.svg";
 import BunjangLogo from "#public/번개장터.svg";
 import JoongnaLogo from "#public/중고나라.svg";

--- a/app/ui/formItems/Input.tsx
+++ b/app/ui/formItems/Input.tsx
@@ -3,8 +3,8 @@
 import { Input as HeadlessInput } from "@headlessui/react";
 import React from "react";
 
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider";
-import { Platform } from "#lib/types/property";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import type { Platform } from "#lib/types/property.js";
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 

--- a/app/ui/formItems/Label.tsx
+++ b/app/ui/formItems/Label.tsx
@@ -3,8 +3,8 @@
 import { Label as HeadlessLabel } from "@headlessui/react";
 import { LabelHTMLAttributes, PropsWithChildren } from "react";
 
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider";
-import { Platform } from "#lib/types/property";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import type { Platform } from "#lib/types/property.js";
 
 interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
   size?: "xl" | "lg" | "md" | "sm";

--- a/app/ui/formItems/Legend.tsx
+++ b/app/ui/formItems/Legend.tsx
@@ -3,8 +3,8 @@
 import { Legend as HeadlessLegend } from "@headlessui/react";
 import { HTMLAttributes, PropsWithChildren } from "react";
 
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider";
-import { Platform } from "#lib/types/property";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import type { Platform } from "#lib/types/property.js";
 
 interface LegendProps extends HTMLAttributes<HTMLLegendElement> {}
 

--- a/app/ui/formItems/RadioTabs.tsx
+++ b/app/ui/formItems/RadioTabs.tsx
@@ -9,9 +9,9 @@ import {
 } from "@headlessui/react";
 import React from "react";
 
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider";
-import { Platform } from "#lib/types/property";
-import Label from "#ui/formItems/Label";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import type { Platform } from "#lib/types/property.js";
+import Label from "#ui/formItems/Label.jsx";
 
 interface RadioTabsProps<ItemType extends string>
   extends RadioGroupProps<"div", ItemType> {

--- a/app/ui/formItems/Select.tsx
+++ b/app/ui/formItems/Select.tsx
@@ -3,8 +3,8 @@
 import { Select as HeadlessSelect } from "@headlessui/react";
 import React, { SelectHTMLAttributes } from "react";
 
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider";
-import { Platform } from "#lib/types/property";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import type { Platform } from "#lib/types/property.js";
 
 interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   options: { value: string; name: string }[];

--- a/app/ui/formItems/SubmitButton.tsx
+++ b/app/ui/formItems/SubmitButton.tsx
@@ -3,7 +3,7 @@
 import { PropsWithChildren } from "react";
 import { useFormStatus } from "react-dom";
 
-import Button from "#ui/Button/Button";
+import Button from "#ui/Button/Button.jsx";
 
 function SubmitButton({ children }: PropsWithChildren<{}>) {
   const { pending } = useFormStatus();

--- a/app/ui/formItems/Textarea.tsx
+++ b/app/ui/formItems/Textarea.tsx
@@ -3,8 +3,8 @@
 import { Textarea as HeadlessTextarea } from "@headlessui/react";
 import React from "react";
 
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider";
-import { Platform } from "#lib/types/property";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import type { Platform } from "#lib/types/property.js";
 
 interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}

--- a/app/ui/formItems/index.tsx
+++ b/app/ui/formItems/index.tsx
@@ -1,11 +1,11 @@
-import ErrorText from "#ui/formItems/ErrorText";
-import Input from "#ui/formItems/Input";
-import Label from "#ui/formItems/Label";
-import Legend from "#ui/formItems/Legend";
-import RadioTabs from "#ui/formItems/RadioTabs";
-import Select from "#ui/formItems/Select";
-import SubmitButton from "#ui/formItems/SubmitButton";
-import Textarea from "#ui/formItems/Textarea";
+import ErrorText from "#ui/formItems/ErrorText.jsx";
+import Input from "#ui/formItems/Input.jsx";
+import Label from "#ui/formItems/Label.jsx";
+import Legend from "#ui/formItems/Legend.jsx";
+import RadioTabs from "#ui/formItems/RadioTabs.jsx";
+import Select from "#ui/formItems/Select.jsx";
+import SubmitButton from "#ui/formItems/SubmitButton.jsx";
+import Textarea from "#ui/formItems/Textarea.jsx";
 
 export {
   ErrorText,

--- a/auth.ts
+++ b/auth.ts
@@ -9,7 +9,7 @@ import Google from "next-auth/providers/google";
 import kakao from "next-auth/providers/kakao";
 import naver from "next-auth/providers/naver";
 
-import { db } from "#lib/database/db";
+import { db } from "#lib/database/db.js";
 
 const providers: Provider[] = [Google, naver, kakao];
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,10 @@ const nextConfig = {
       test: /\.svg$/,
       use: ["@svgr/webpack"],
     });
+    config.resolve.extensionAlias = {
+      ".js": [".ts", ".js"],
+      ".jsx": [".tsx", ".jsx"],
+    };
     return config;
   },
 };

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "oauth4webapi": "npm:@jacobkim/oauth4webapi@^2.10.4"
   },
   "imports": {
-    "#lib/database/posts.js": {
+    "#lib/database/posts": {
       "storybook": "./app/lib/database/posts.mock.ts",
       "default": "./app/lib/database/posts.ts"
     },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "oauth4webapi": "npm:@jacobkim/oauth4webapi@^2.10.4"
   },
   "imports": {
-    "#lib/database/posts": {
+    "#lib/database/posts.js": {
       "storybook": "./app/lib/database/posts.mock.ts",
       "default": "./app/lib/database/posts.ts"
     },

--- a/package.json
+++ b/package.json
@@ -70,9 +70,9 @@
     "oauth4webapi": "npm:@jacobkim/oauth4webapi@^2.10.4"
   },
   "imports": {
-    "#lib/database/db": {
-      "storybook": "./app/lib/database/db.mock.ts",
-      "default": "./app/lib/database/db.ts"
+    "#lib/database/posts": {
+      "storybook": "./app/lib/database/posts.mock.ts",
+      "default": "./app/lib/database/posts.ts"
     },
     "#auth": {
       "storybook": "./auth.mock.ts",

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -74,7 +74,7 @@ export async function create() {
     .addColumn("platform", "text", (col) => col.notNull())
     .addColumn("targetNickname", "text", (col) => col.notNull())
     .addColumn("tag", "text", (col) => col.notNull())
-    .addColumn("imageUrls", sql`text[]`, (col) => col.notNull())
+    .addColumn("images", sql`text[]`)
     .addColumn("content", "text", (col) => col.notNull())
     .addColumn("status", "text", (col) => col.defaultTo("normal").notNull())
     .addColumn("createdAt", "timestamptz", (col) =>
@@ -127,6 +127,14 @@ export async function create() {
     .column("postId")
     .execute();
 
+  await db.schema
+    .createTable("Image")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`)
+    )
+    .addColumn("url", "text", (col) => col.notNull())
+    .execute();
+
   console.log("Migration completed");
 }
 
@@ -137,6 +145,7 @@ export async function drop() {
   await db.schema.dropTable("VerificationToken").ifExists().execute();
   await db.schema.dropTable("Account").ifExists().execute();
   await db.schema.dropTable("User").ifExists().execute();
+  await db.schema.dropTable("Image").ifExists().execute();
 
   console.log("Rollback completed");
 }

--- a/stories/Banner.stories.tsx
+++ b/stories/Banner.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import Banner from "#ui/Banner/Banner";
+import Banner from "#ui/Banner/Banner.jsx";
 
 const meta = {
   title: "ui/Banner",

--- a/stories/Header.stories.tsx
+++ b/stories/Header.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { expect, userEvent, waitFor, within } from "@storybook/test";
 
-import { auth } from "#auth.mock";
-import { PlatformStoreProvider } from "#lib/providers/PlatformStoreProvider";
-import { SearchStoreProvider } from "#lib/providers/SearchStoreProvider";
-import Header from "#ui/Header/Header";
+import { auth } from "#auth.mock.js";
+import { PlatformStoreProvider } from "#lib/providers/PlatformStoreProvider.jsx";
+import { SearchStoreProvider } from "#lib/providers/SearchStoreProvider.jsx";
+import Header from "#ui/Header/Header.jsx";
 
 const meta = {
   title: "ui/Header",

--- a/stories/PostCreateForm.stories.tsx
+++ b/stories/PostCreateForm.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { expect, userEvent, waitFor, within } from "@storybook/test";
 
-import PostCreateForm from "#app/post/create/form";
+import PostCreateForm from "#app/post/create/form.jsx";
 import { auth } from "#auth.mock.js";
-import { FormValues } from "#lib/actions/createPostAction";
-import { ERROR } from "#lib/constants/messages";
+import type { FormValues } from "#lib/actions/createPostAction.js";
+import { ERROR } from "#lib/constants/messages.js";
 import { createPost } from "#lib/database/posts.mock.js";
-import { PlatformStoreProvider } from "#lib/providers/PlatformStoreProvider";
+import { PlatformStoreProvider } from "#lib/providers/PlatformStoreProvider.jsx";
 
 const meta = {
   title: "form/PostCreateForm",

--- a/stories/PostCreateForm.stories.tsx
+++ b/stories/PostCreateForm.stories.tsx
@@ -1,13 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { expect, userEvent, waitFor, within } from "@storybook/test";
-import { Kysely } from "kysely";
 
 import PostCreateForm from "#app/post/create/form";
 import { auth } from "#auth.mock";
 import { FormValues } from "#lib/actions/createPostAction";
 import { ERROR } from "#lib/constants/messages";
-import { Database } from "#lib/database/db";
-import { getDB } from "#lib/database/db.mock";
+import { createPost } from "#lib/database/posts.mock";
 import { PlatformStoreProvider } from "#lib/providers/PlatformStoreProvider";
 
 const meta = {
@@ -21,14 +19,10 @@ const meta = {
     (Story) => <PlatformStoreProvider>{Story()}</PlatformStoreProvider>,
   ],
   async beforeEach() {
-    const mockInsertBuilder = {
-      insertInto: () => mockInsertBuilder,
-      values: () => mockInsertBuilder,
-      returning: () => mockInsertBuilder,
-      executeTakeFirstOrThrow: () => mockInsertBuilder,
-      id: "postId",
-    };
-    getDB.mockReturnValue(mockInsertBuilder as unknown as Kysely<Database>);
+    const mockResult = new Promise<{ id: string }>((resolve) => {
+      resolve({ id: "postId" });
+    });
+    createPost.mockReturnValue(mockResult);
   },
 } satisfies Meta<typeof PostCreateForm>;
 
@@ -70,7 +64,7 @@ export const NonSession: Story = {
       await userEvent.click(submitButton);
       await waitFor(() => {
         expect(contentTextarea).toHaveFocus();
-        expect(getDB).not.toBeCalled();
+        expect(createPost).not.toBeCalled();
       });
     });
 
@@ -83,7 +77,7 @@ export const NonSession: Story = {
       await waitFor(() => {
         expect(canvas.getByText(ERROR.NO_TARGET_NICKNAME)).toBeInTheDocument();
         expect(targetNicknameInput).toHaveFocus();
-        expect(getDB).not.toBeCalled();
+        expect(createPost).not.toBeCalled();
       });
     });
 
@@ -106,7 +100,7 @@ export const NonSession: Story = {
 
       await userEvent.click(submitButton);
       await waitFor(() => {
-        expect(getDB).toBeCalled();
+        expect(createPost).toBeCalled();
       });
     });
   },

--- a/stories/PostCreateForm.stories.tsx
+++ b/stories/PostCreateForm.stories.tsx
@@ -2,10 +2,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { expect, userEvent, waitFor, within } from "@storybook/test";
 
 import PostCreateForm from "#app/post/create/form";
-import { auth } from "#auth.mock";
+import { auth } from "#auth.mock.js";
 import { FormValues } from "#lib/actions/createPostAction";
 import { ERROR } from "#lib/constants/messages";
-import { createPost } from "#lib/database/posts.mock";
+import { createPost } from "#lib/database/posts.mock.js";
 import { PlatformStoreProvider } from "#lib/providers/PlatformStoreProvider";
 
 const meta = {

--- a/stories/SearchBar.stories.tsx
+++ b/stories/SearchBar.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { expect, userEvent, waitFor, within } from "@storybook/test";
 
-import { PlatformStoreProvider } from "#lib/providers/PlatformStoreProvider";
-import { SearchStoreProvider } from "#lib/providers/SearchStoreProvider";
-import SearchBar from "#ui/SearchBar/SearchBar";
+import { PlatformStoreProvider } from "#lib/providers/PlatformStoreProvider.jsx";
+import { SearchStoreProvider } from "#lib/providers/SearchStoreProvider.jsx";
+import SearchBar from "#ui/SearchBar/SearchBar.jsx";
 
 const meta = {
   title: "ui/SearchBar",

--- a/stories/SearchList.stories.tsx
+++ b/stories/SearchList.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { PlatformStoreProvider } from "#lib/providers/PlatformStoreProvider";
-import { SearchStoreProvider } from "#lib/providers/SearchStoreProvider";
-import Search from "#ui/Search/Search";
+import { PlatformStoreProvider } from "#lib/providers/PlatformStoreProvider.jsx";
+import { SearchStoreProvider } from "#lib/providers/SearchStoreProvider.jsx";
+import Search from "#ui/Search/Search.jsx";
 
 const meta = {
   title: "ui/Search",


### PR DESCRIPTION
# 구현 내용
- 기존은 DB 목업을 `getDB`의 별개 함수를 생성해  db를 mocking하던 방식
  - 포스트 생성 로직을 분리해 추상화한 `createPost`를 mocking하도록 변경
- DB에 image를 object로 저장하는 방식에서 관계형으로 수정
- subpath import 설정 후 vscode 자동완성이 확장자를 추가하도록 바뀌면서 프레임워크와 충돌
  - 해결을 위해 Next.js와 Storybook에서 사용하는 webpack에 `extensionAlias` 설정을 추가
- 기존 import 문들이 확장자 없는 버전으로 선언되어 있었는데  기능 구현 중 의미없는 diff가 올라가는 것을 막기위해 자동완성 포멧으로 통일

# 이슈 번호
- close #37 