### PR TITLE
목록 더보기 버튼 추가

### DIFF
--- a/app/api/v1/posts/route.ts
+++ b/app/api/v1/posts/route.ts
@@ -8,9 +8,9 @@ export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const nickname = searchParams.get("nickname");
   const platform = searchParams.get("platform");
-  const cursor = Number(searchParams.get("cursor"));
-  const limit = Number(searchParams.get("limit"));
-  const isExclude = searchParams.get("isExclude");
+  const cursorParam = searchParams.get("cursor");
+  const limitParam = searchParams.get("limit");
+  const isExclude = searchParams.get("exclude");
 
   if (!nickname) {
     return NextResponse.json(
@@ -24,12 +24,15 @@ export async function GET(request: NextRequest) {
       { status: 400 }
     );
   }
+
+  const cursor = cursorParam ? Number(cursorParam) : Number.MAX_SAFE_INTEGER;
   if (Number.isNaN(cursor)) {
     return NextResponse.json(
       { error: "cursor is incorrect." },
       { status: 400 }
     );
   }
+  const limit = limitParam ? Number(limitParam) : 10;
   if (Number.isNaN(limit)) {
     return NextResponse.json({ error: "limit is incorrect." }, { status: 400 });
   }
@@ -43,7 +46,10 @@ export async function GET(request: NextRequest) {
       isExclude: !(isExclude === null || isExclude === "false"),
     });
 
-    return NextResponse.json(posts);
+    return NextResponse.json({
+      data: posts,
+      nextCursor: posts[posts.length - 1].id,
+    });
   } catch (err) {
     return NextResponse.json(
       { error: "Database error occurred" },

--- a/app/api/v1/posts/route.ts
+++ b/app/api/v1/posts/route.ts
@@ -1,12 +1,53 @@
-import type { NextRequest } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 
-import { getPostsByNickname } from "#lib/database/posts";
+import { PLATFORM_ID } from "#lib/constants/platform.js";
+import { getPostsByNicknamePlatform } from "#lib/database/posts";
+import type { Platform } from "#lib/types/property.js";
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const nickname = searchParams.get("nickname");
+  const platform = searchParams.get("platform");
+  const cursor = Number(searchParams.get("cursor"));
+  const limit = Number(searchParams.get("limit"));
+  const isExclude = searchParams.get("isExclude");
 
-  const posts = await getPostsByNickname(nickname ?? "");
+  if (!nickname) {
+    return NextResponse.json(
+      { error: "nickname is required." },
+      { status: 400 }
+    );
+  }
+  if (!platform || !(platform in PLATFORM_ID)) {
+    return NextResponse.json(
+      { error: "platform is incorrect." },
+      { status: 400 }
+    );
+  }
+  if (Number.isNaN(cursor)) {
+    return NextResponse.json(
+      { error: "cursor is incorrect." },
+      { status: 400 }
+    );
+  }
+  if (Number.isNaN(limit)) {
+    return NextResponse.json({ error: "limit is incorrect." }, { status: 400 });
+  }
 
-  return Response.json(posts);
+  try {
+    const posts = await getPostsByNicknamePlatform({
+      nickname,
+      platform: platform as Platform,
+      cursor,
+      limit,
+      isExclude: !(isExclude === null || isExclude === "false"),
+    });
+
+    return NextResponse.json(posts);
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Database error occurred" },
+      { status: 500 }
+    );
+  }
 }

--- a/app/lib/actions/comment/createCommentAction.ts
+++ b/app/lib/actions/comment/createCommentAction.ts
@@ -23,7 +23,7 @@ const formSchema = z.object({
 export type CommentFormValues = z.infer<typeof formSchema>;
 
 export async function createCommentAction(
-  postId: string,
+  postId: number,
   prevState: ActionState,
   formData: FormData
 ): Promise<ActionState> {

--- a/app/lib/actions/post/deletePostAction.ts
+++ b/app/lib/actions/post/deletePostAction.ts
@@ -8,7 +8,7 @@ import { deletePost, getPost } from "#lib/database/posts";
 import type { ActionState } from "#lib/types/action.js";
 
 export async function deletePostAction(
-  id: string,
+  id: number,
   prevState: ActionState,
   formData: FormData
 ): Promise<ActionState> {

--- a/app/lib/actions/post/updatePostAction.ts
+++ b/app/lib/actions/post/updatePostAction.ts
@@ -34,7 +34,7 @@ const formSchema = z
 export type PostUpdateFormValues = z.infer<typeof formSchema>;
 
 export async function updatePostAction(
-  id: string,
+  id: number,
   prevState: ActionState,
   formData: FormData
 ): Promise<ActionState> {

--- a/app/lib/constants/platform.ts
+++ b/app/lib/constants/platform.ts
@@ -1,5 +1,7 @@
 import type { FormColor, Platform } from "#lib/types/property.js";
 
+export const PLATFORM_SET = new Set(["daangn", "bunjang", "joongna", "etc"]);
+
 export const PLATFORM_ID: { [key: number]: Platform } = [
   "daangn",
   "bunjang",

--- a/app/lib/database/comments.ts
+++ b/app/lib/database/comments.ts
@@ -19,7 +19,7 @@ export function createComment(newCommentData: NewCommentData) {
     .executeTakeFirstOrThrow();
 }
 
-export const getComments = cache((postId: string) =>
+export const getComments = cache((postId: number) =>
   db
     .selectFrom("Comment")
     .innerJoin("User", "User.id", "Comment.userId")

--- a/app/lib/database/db.ts
+++ b/app/lib/database/db.ts
@@ -41,7 +41,7 @@ export interface Database {
     expires: Date;
   };
   Post: {
-    id: GeneratedAlways<string>;
+    id: GeneratedAlways<number>;
     userId: string;
     platform: Platform;
     targetNickname: string;
@@ -57,7 +57,7 @@ export interface Database {
   Comment: {
     id: GeneratedAlways<string>;
     userId: string;
-    postId: string;
+    postId: number;
     images: string[] | null;
     content: string;
     status: PostCommentStatus;

--- a/app/lib/hooks/useInfiniteSearch.ts
+++ b/app/lib/hooks/useInfiniteSearch.ts
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react";
+import type { Fetcher } from "swr";
+import type { SWRInfiniteKeyLoader } from "swr/infinite";
+import useSWRInfinite from "swr/infinite";
+
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import { useSearchStore } from "#lib/providers/SearchStoreProvider.jsx";
+import type { Platform } from "#lib/types/property.js";
+import type {
+  InfinitePostsInfo,
+  TroublemakerInfo,
+} from "#lib/types/response.js";
+import type { SearchState } from "#lib/types/state.js";
+
+const DEBOUNCE_INTERVAL = 200;
+const LIMIT = 10;
+
+const getKey: (
+  nickname: string,
+  platform: Platform,
+  isExclude?: boolean
+) => SWRInfiniteKeyLoader<InfinitePostsInfo> =
+  (nickname, platform, isExclude) => (pageIndex, previousPageData) => {
+    if (previousPageData && !previousPageData.data) return null;
+
+    const searchQuery = `nickname=${nickname}&platform=${platform}${isExclude ? "&exclude=1" : ""}`;
+
+    if (pageIndex === 0 || !previousPageData)
+      return `/api/v1/posts?${searchQuery}&limit=${LIMIT}`;
+
+    return `/api/v1/posts?${searchQuery}&cursor=${previousPageData.nextCursor}&limit=${LIMIT}`;
+  };
+
+const fetcher: Fetcher<InfinitePostsInfo, string> = (url) =>
+  fetch(url).then((res) => res.json());
+
+const getInfiniteStatus = (
+  isLoading: boolean,
+  size: number,
+  error: any,
+  infiniteData?: InfinitePostsInfo[]
+): SearchState["status"] => {
+  const isLoadingMore =
+    isLoading ||
+    (size > 0 && infiniteData && typeof infiniteData[size - 1] === "undefined");
+  const isEmpty = infiniteData?.[0].data.length === 0;
+  const isReachingEnd =
+    isEmpty ||
+    (infiniteData && infiniteData[infiniteData.length - 1].data.length < LIMIT);
+
+  if (isLoading) return "LOADING";
+  if (isLoadingMore) return "LOADING_MORE";
+  if (isReachingEnd) return "END";
+  if (error) return "ERROR";
+  return "READY";
+};
+
+interface UseInfiniteSearchProps {
+  onChange?: () => void;
+  isExclude?: boolean;
+}
+
+export default function useInfiniteSearch({
+  onChange,
+  isExclude,
+}: UseInfiniteSearchProps) {
+  const query = useSearchStore((state) => state.query);
+  const platform = usePlatformStore((state) => state.platform);
+
+  const [platformKey, setPlatformKey] = useState<ReturnType<typeof getKey>>(
+    getKey("", platform, isExclude)
+  );
+  const { data, isLoading, error, size, setSize } = useSWRInfinite(
+    platformKey,
+    fetcher
+  );
+
+  const state: SearchState = {
+    status: getInfiniteStatus(isLoading, size, error, data),
+    troublemakers: new Array<TroublemakerInfo>().concat(
+      ...(data?.map((info) => info.data) ?? [])
+    ),
+  };
+
+  useEffect(() => {
+    const timeoutId = setTimeout(async () => {
+      setPlatformKey(getKey(query, platform));
+
+      onChange?.();
+    }, DEBOUNCE_INTERVAL);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [query, platform, onChange]);
+
+  return {
+    state,
+    setSize,
+  };
+}

--- a/app/lib/hooks/useInfiniteSearch.ts
+++ b/app/lib/hooks/useInfiniteSearch.ts
@@ -72,7 +72,6 @@ export default function useInfiniteSearch({
     InfinitePostsInfo,
     Error
   >(getKey(...keyParams), fetcher);
-  console.log(data, keyParams, isLoading, error?.cause);
 
   const state: SearchState = {
     status: getInfiniteStatus(isLoading, size, error, data),
@@ -95,6 +94,7 @@ export default function useInfiniteSearch({
 
   return {
     state,
+    size,
     setSize,
   };
 }

--- a/app/lib/providers/SearchListProvider.tsx
+++ b/app/lib/providers/SearchListProvider.tsx
@@ -46,6 +46,7 @@ export const SearchListProvider = ({ children }: SearchListProviderProps) => {
     });
   const { state: othersState, setSize: setOthersSize } = useInfiniteSearch({
     onChange: handleQueryKeyChange,
+    isExclude: true,
   });
 
   const handleInputKeyDown: KeyboardEventHandler<HTMLDivElement> = (e) => {

--- a/app/lib/providers/SearchListProvider.tsx
+++ b/app/lib/providers/SearchListProvider.tsx
@@ -7,6 +7,7 @@ import {
   type RefObject,
   useCallback,
   useContext,
+  useEffect,
   useRef,
   useState,
 } from "react";
@@ -32,6 +33,14 @@ interface SearchListProviderProps {
 export const SearchListProvider = ({ children }: SearchListProviderProps) => {
   const searchListRef = useRef<HTMLUListElement | HTMLOListElement>(null);
   const [activeItemIdx, setActiveItemIdx] = useState(0);
+
+  useEffect(() => {
+    if (!searchListRef.current) return;
+
+    scrollToActiveItem(
+      searchListRef.current.querySelectorAll("li")[activeItemIdx]
+    );
+  }, [activeItemIdx]);
 
   const handleQueryKeyChange = useCallback(() => setActiveItemIdx(-1), []);
   const {
@@ -100,3 +109,20 @@ export const useSearchListContext = () => {
 
   return searchListContext;
 };
+
+const HEADER_HEIGHT = 56;
+
+function scrollToActiveItem(item: HTMLLIElement) {
+  if (typeof window === "undefined" || !item) return;
+
+  const { top, bottom } = item.getBoundingClientRect();
+  if (top < HEADER_HEIGHT) {
+    window.scrollBy({ top: top - HEADER_HEIGHT });
+  }
+
+  const windowHeight =
+    window.innerHeight || document.documentElement.clientHeight;
+  if (bottom > windowHeight) {
+    window.scrollBy({ top: bottom - windowHeight });
+  }
+}

--- a/app/lib/providers/SearchListProvider.tsx
+++ b/app/lib/providers/SearchListProvider.tsx
@@ -12,21 +12,15 @@ import {
 } from "react";
 
 import useInfiniteSearch from "#lib/hooks/useInfiniteSearch.js";
-import type { InfinitePostsInfo } from "#lib/types/response.js";
 import type { SearchState } from "#lib/types/state.js";
 
 interface SearchListValue {
   activeItemIdx: number;
   searchListRef: RefObject<HTMLUListElement | HTMLOListElement>;
   troublemakersState: SearchState;
-  setTroublemakersSize: (
-    size: number | ((_size: number) => number)
-  ) => Promise<InfinitePostsInfo[] | undefined>;
   othersState: SearchState;
-  setOthersSize: (
-    size: number | ((_size: number) => number)
-  ) => Promise<InfinitePostsInfo[] | undefined>;
   handleInputKeyDown: KeyboardEventHandler<HTMLDivElement>;
+  handleMoreClick: (isExclude?: boolean) => () => void;
 }
 
 const SearchListContext = createContext<SearchListValue | null>(null);
@@ -40,11 +34,18 @@ export const SearchListProvider = ({ children }: SearchListProviderProps) => {
   const [activeItemIdx, setActiveItemIdx] = useState(0);
 
   const handleQueryKeyChange = useCallback(() => setActiveItemIdx(-1), []);
-  const { state: troublemakersState, setSize: setTroublemakersSize } =
-    useInfiniteSearch({
-      onChange: handleQueryKeyChange,
-    });
-  const { state: othersState, setSize: setOthersSize } = useInfiniteSearch({
+  const {
+    state: troublemakersState,
+    size: troublemakersSize,
+    setSize: setTroublemakersSize,
+  } = useInfiniteSearch({
+    onChange: handleQueryKeyChange,
+  });
+  const {
+    state: othersState,
+    size: othersSize,
+    setSize: setOthersSize,
+  } = useInfiniteSearch({
     onChange: handleQueryKeyChange,
     isExclude: true,
   });
@@ -64,14 +65,21 @@ export const SearchListProvider = ({ children }: SearchListProviderProps) => {
     }
   };
 
+  const handleMoreClick = (isExclude?: boolean) => () => {
+    if (isExclude) {
+      setOthersSize(othersSize + 1);
+    } else {
+      setTroublemakersSize(troublemakersSize + 1);
+    }
+  };
+
   const value: SearchListValue = {
     activeItemIdx,
     searchListRef,
     troublemakersState,
-    setTroublemakersSize,
     othersState,
-    setOthersSize,
     handleInputKeyDown,
+    handleMoreClick,
   };
 
   return (

--- a/app/lib/types/action.ts
+++ b/app/lib/types/action.ts
@@ -2,7 +2,7 @@ export type ActionState =
   | {
       status: "SUCCESS";
       message: string;
-      resultId?: string;
+      resultId?: number | string;
     }
   | {
       status: "ERROR_VALIDATE";

--- a/app/lib/types/response.ts
+++ b/app/lib/types/response.ts
@@ -11,3 +11,8 @@ export type TroublemakerInfo =
   ReturnType<typeof getPostsByNicknamePlatform> extends Promise<(infer T)[]>
     ? T
     : never;
+
+export type InfinitePostsInfo = {
+  data: TroublemakerInfo[];
+  nextCursor: number;
+};

--- a/app/lib/types/response.ts
+++ b/app/lib/types/response.ts
@@ -1,5 +1,5 @@
 import type { getComments } from "#lib/database/comments.js";
-import type { getPost, getPostsByNickname } from "#lib/database/posts";
+import type { getPost, getPostsByNicknamePlatform } from "#lib/database/posts";
 
 export type PostInfo =
   ReturnType<typeof getPost> extends Promise<infer T> ? T : never;
@@ -8,6 +8,6 @@ export type CommentInfo =
   ReturnType<typeof getComments> extends Promise<(infer T)[]> ? T : never;
 
 export type TroublemakerInfo =
-  ReturnType<typeof getPostsByNickname> extends Promise<(infer T)[]>
+  ReturnType<typeof getPostsByNicknamePlatform> extends Promise<(infer T)[]>
     ? T
     : never;

--- a/app/lib/types/state.ts
+++ b/app/lib/types/state.ts
@@ -1,7 +1,6 @@
 import type { TroublemakerInfo } from "#lib/types/response.js";
 
 export type SearchState = {
-  status: "LOADING" | "SUCCESS" | "ERROR";
+  status: "LOADING" | "LOADING_MORE" | "READY" | "END" | "ERROR";
   troublemakers: TroublemakerInfo[];
-  otherPlatformTroublemakers: TroublemakerInfo[];
 };

--- a/app/post/[id]/(author)/AuthorContainer.tsx
+++ b/app/post/[id]/(author)/AuthorContainer.tsx
@@ -5,7 +5,7 @@ import AuthorTag from "#ui/AuthorTag/AuthorTag.jsx";
 import CommentLine from "#ui/SIdeLine/CommentLine.jsx";
 
 interface AuthorContainerProps {
-  postId: string;
+  postId: number;
 }
 
 export default async function AuthorContainer({

--- a/app/post/[id]/(comment)/CommentContainer.tsx
+++ b/app/post/[id]/(comment)/CommentContainer.tsx
@@ -3,7 +3,7 @@ import CommentForm from "#app/post/[id]/(comment)/form.jsx";
 import { auth } from "#auth";
 
 interface CommentContainerProps {
-  postId: string;
+  postId: number;
 }
 
 export default async function CommentContainer({

--- a/app/post/[id]/(comment)/_component/CommentList.tsx
+++ b/app/post/[id]/(comment)/_component/CommentList.tsx
@@ -6,7 +6,7 @@ import { getComments } from "#lib/database/comments.js";
 import Dot from "#ui/Dot/Dot.jsx";
 
 interface CommentListProps extends ComponentProps<"section"> {
-  postId: string;
+  postId: number;
 }
 
 export default async function CommentList({

--- a/app/post/[id]/(comment)/form.tsx
+++ b/app/post/[id]/(comment)/form.tsx
@@ -22,7 +22,7 @@ import {
 
 interface CommentFormProps {
   session: Session | null;
-  postId: string;
+  postId: number;
 }
 
 export default function CommentForm({ session, postId }: CommentFormProps) {

--- a/app/post/[id]/_components/ContentContainer/ContentContainer.tsx
+++ b/app/post/[id]/_components/ContentContainer/ContentContainer.tsx
@@ -7,7 +7,7 @@ import Dot from "#ui/Dot/Dot.jsx";
 import CommentLine from "#ui/SIdeLine/CommentLine.jsx";
 
 interface ContentContainerProps {
-  postId: string;
+  postId: number;
 }
 
 export default async function ContentContainer({

--- a/app/post/[id]/_components/ContentContainer/PostMutationForm.tsx
+++ b/app/post/[id]/_components/ContentContainer/PostMutationForm.tsx
@@ -5,7 +5,7 @@ import useDeleteAction from "#lib/hooks/useDeleteAction.js";
 import MutationButtonGroup from "#ui/MutationButtonGroup/MutationButtonGroup.jsx";
 
 interface PostMutationFormProps {
-  postId: string;
+  postId: number;
 }
 
 export default function PostMutationForm({ postId }: PostMutationFormProps) {

--- a/app/post/[id]/_components/TitleBar/TitleBar.tsx
+++ b/app/post/[id]/_components/TitleBar/TitleBar.tsx
@@ -9,7 +9,7 @@ import CategoryItem from "#ui/SearchBar/CategoryItem.jsx";
 import TagItem from "#ui/TagItem/TagItem.jsx";
 
 interface TitlebarProps {
-  postId: string;
+  postId: number;
 }
 
 export default async function TitleBar({ postId }: TitlebarProps) {

--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -8,7 +8,7 @@ export default async function PostDetailPage({
 }: {
   params: { id: string };
 }) {
-  const id = params.id;
+  const id = Number(params.id);
   return (
     <>
       <TitleBar postId={id} />

--- a/app/post/update/[id]/page.tsx
+++ b/app/post/update/[id]/page.tsx
@@ -9,6 +9,8 @@ export default async function PostUpdatePage({
 }: {
   params: { id: string };
 }) {
+  const id = Number(params.id);
+
   const session = await auth();
   const {
     userId,
@@ -19,15 +21,15 @@ export default async function PostUpdatePage({
     images,
     platform,
     additionalInfo,
-  } = await getPost(params.id);
+  } = await getPost(id);
 
   if (!session || session.user?.id !== userId) {
-    redirect(`/post/${params.id}`);
+    redirect(`/post/${id}`);
   }
 
   return (
     <PostForm
-      id={params.id}
+      id={id}
       content={content}
       etcPlatformName={etcPlatformName}
       images={images}

--- a/app/ui/Header/HeaderSearch.tsx
+++ b/app/ui/Header/HeaderSearch.tsx
@@ -20,6 +20,7 @@ interface HeaderSearchProps extends PopoverProps {}
 function HeaderSearch({ className = "", ...props }: HeaderSearchProps) {
   const pathname = usePathname();
   const isHome = pathname === "/";
+  if (isHome) return null;
 
   const handlePopoverButtonClick =
     (open: boolean) => (e: MouseEvent<HTMLDivElement>) => {
@@ -39,7 +40,7 @@ function HeaderSearch({ className = "", ...props }: HeaderSearchProps) {
     "h-[70vh] pb-16 rounded-b-2xl max-sm:-translate-x-12 max-sm:w-full-plus-6rem";
 
   return (
-    <Popover className={`${isHome ? "hidden" : ""} ${className}`} {...props}>
+    <Popover className={`${className}`} {...props}>
       {({ open }) => (
         <SearchListProvider>
           <PopoverOverlay className="fixed inset-0 bg-black/15" />

--- a/app/ui/SearchList/MoreButton.tsx
+++ b/app/ui/SearchList/MoreButton.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { ComponentProps } from "react";
+
+import { PLATFORM_COLOR } from "#lib/constants/platform.js";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import type { SearchState } from "#lib/types/state.js";
+import Button from "#ui/Button/Button.jsx";
+
+interface MoreButtonProps extends ComponentProps<"button"> {
+  status: SearchState["status"];
+}
+
+export default function MoreButton({
+  status,
+  className,
+  ...props
+}: MoreButtonProps) {
+  const platform = usePlatformStore((state) => state.platform);
+
+  const loading = status === "LOADING_MORE";
+  const disabled =
+    status === "END" || status === "ERROR" || status === "LOADING";
+
+  return (
+    <Button
+      color={PLATFORM_COLOR[platform]}
+      theme="sub"
+      loading={loading}
+      className={`mt-3 ${disabled ? "hidden" : ""}`}
+      {...props}>
+      더보기
+    </Button>
+  );
+}

--- a/app/ui/SearchList/MoreButton.tsx
+++ b/app/ui/SearchList/MoreButton.tsx
@@ -1,21 +1,16 @@
 "use client";
 
-import type { ComponentProps } from "react";
-
 import { PLATFORM_COLOR } from "#lib/constants/platform.js";
 import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
 import type { SearchState } from "#lib/types/state.js";
 import Button from "#ui/Button/Button.jsx";
 
-interface MoreButtonProps extends ComponentProps<"button"> {
+interface MoreButtonProps {
   status: SearchState["status"];
+  onClick: () => void;
 }
 
-export default function MoreButton({
-  status,
-  className,
-  ...props
-}: MoreButtonProps) {
+export default function MoreButton({ status, onClick }: MoreButtonProps) {
   const platform = usePlatformStore((state) => state.platform);
 
   const loading = status === "LOADING_MORE";
@@ -28,7 +23,7 @@ export default function MoreButton({
       theme="sub"
       loading={loading}
       className={`mt-3 ${disabled ? "hidden" : ""}`}
-      {...props}>
+      onClick={onClick}>
       더보기
     </Button>
   );

--- a/app/ui/SearchList/SearchList.tsx
+++ b/app/ui/SearchList/SearchList.tsx
@@ -6,6 +6,7 @@ import { PLATFORM_COLOR } from "#lib/constants/platform.js";
 import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
 import { useSearchListContext } from "#lib/providers/SearchListProvider.jsx";
 import type { TroublemakerInfo } from "#lib/types/response.js";
+import type { SearchState } from "#lib/types/state.js";
 import Divider from "#ui/Divider/Divider.jsx";
 import Dot from "#ui/Dot/Dot.jsx";
 import Loading from "#ui/SearchList/Loading.jsx";
@@ -18,62 +19,16 @@ export default function SearchList({ className, ...props }: SearchListProps) {
   const platform = usePlatformStore((state) => state.platform);
   const {
     activeItemIdx,
-    troublemakersStatus: { status, troublemakers, otherPlatformTroublemakers },
     searchListRef,
+    troublemakersState,
+    setTroublemakersSize,
+    othersState,
+    setOthersSize,
   } = useSearchListContext();
 
-  let Items: JSX.Element | JSX.Element[] = <></>;
-  let OtherPlatformItems: JSX.Element | JSX.Element[] = <></>;
-  let idxCounter = 0;
-  const troublemakerMapper = (troublemaker: TroublemakerInfo) => (
-    <Fragment key={troublemaker.id}>
-      <SearchListItem
-        itemInfo={troublemaker}
-        isActive={idxCounter++ === activeItemIdx}
-      />
-      <Divider direction="horizon" />
-    </Fragment>
-  );
-
-  if (status === "LOADING") {
-    Items = (
-      <>
-        <Loading />
-        <Divider direction="horizon" />
-      </>
-    );
-    OtherPlatformItems = (
-      <>
-        <Loading single />
-        <Divider direction="horizon" />
-      </>
-    );
-  } else {
-    if (status === "SUCCESS") {
-      if (troublemakers.length > 0) {
-        Items = troublemakers.map(troublemakerMapper);
-      }
-      if (otherPlatformTroublemakers.length > 0) {
-        OtherPlatformItems = otherPlatformTroublemakers.map(troublemakerMapper);
-      }
-    }
-    if (status === "ERROR" || troublemakers.length <= 0) {
-      Items = (
-        <>
-          <NoResults error={status === "ERROR"} />
-          <Divider direction="horizon" />
-        </>
-      );
-    }
-    if (status === "ERROR" || otherPlatformTroublemakers.length <= 0) {
-      OtherPlatformItems = (
-        <>
-          <NoResults error={status === "ERROR"} single />
-          <Divider direction="horizon" />
-        </>
-      );
-    }
-  }
+  const itemFactory = convertItems();
+  const Troublemakers = itemFactory(troublemakersState, activeItemIdx);
+  const Others = itemFactory(othersState, activeItemIdx, true);
 
   return (
     <ul
@@ -82,10 +37,68 @@ export default function SearchList({ className, ...props }: SearchListProps) {
       aria-label="검색목록"
       {...props}>
       <Divider direction="horizon" />
-      {Items}
+      {Troublemakers}
       <Dot color={PLATFORM_COLOR[platform]} className="mx-auto my-8" />
       <Divider direction="horizon" />
-      {OtherPlatformItems}
+      {Others}
     </ul>
   );
+}
+
+function convertItems() {
+  let idxCounter = 0;
+
+  return function ConvertedItems(
+    state: SearchState,
+    activeItemIdx: number,
+    single?: boolean
+  ) {
+    let Items: JSX.Element | JSX.Element[] = <></>;
+    const troublemakerMapper = (troublemaker: TroublemakerInfo) => (
+      <Fragment key={troublemaker.id}>
+        <SearchListItem
+          itemInfo={troublemaker}
+          isActive={idxCounter++ === activeItemIdx}
+        />
+        <Divider direction="horizon" />
+      </Fragment>
+    );
+
+    const { status, troublemakers } = state;
+    if (status === "LOADING") {
+      Items = (
+        <>
+          <Loading single={single} />
+          <Divider direction="horizon" />
+        </>
+      );
+    } else if (status === "ERROR") {
+      Items = (
+        <>
+          <NoResults error={true} single={single} />
+          <Divider direction="horizon" />
+        </>
+      );
+    } else if (troublemakers.length <= 0) {
+      Items = (
+        <>
+          <NoResults single={single} />
+          <Divider direction="horizon" />
+        </>
+      );
+    } else {
+      Items = troublemakers.map(troublemakerMapper);
+
+      if (status === "LOADING_MORE") {
+        Items.push(
+          <>
+            <Loading single={single} />
+            <Divider direction="horizon" />
+          </>
+        );
+      }
+    }
+
+    return Items;
+  };
 }

--- a/app/ui/SearchList/SearchList.tsx
+++ b/app/ui/SearchList/SearchList.tsx
@@ -10,6 +10,7 @@ import type { SearchState } from "#lib/types/state.js";
 import Divider from "#ui/Divider/Divider.jsx";
 import Dot from "#ui/Dot/Dot.jsx";
 import Loading from "#ui/SearchList/Loading.jsx";
+import MoreButton from "#ui/SearchList/MoreButton.jsx";
 import NoResults from "#ui/SearchList/NoResults.jsx";
 import SearchListItem from "#ui/SearchList/SearchListItem.jsx";
 
@@ -21,9 +22,8 @@ export default function SearchList({ className, ...props }: SearchListProps) {
     activeItemIdx,
     searchListRef,
     troublemakersState,
-    setTroublemakersSize,
     othersState,
-    setOthersSize,
+    handleMoreClick,
   } = useSearchListContext();
 
   const itemFactory = convertItems();
@@ -38,9 +38,14 @@ export default function SearchList({ className, ...props }: SearchListProps) {
       {...props}>
       <Divider direction="horizon" />
       {Troublemakers}
+      <MoreButton
+        status={troublemakersState.status}
+        onClick={handleMoreClick()}
+      />
       <Dot color={PLATFORM_COLOR[platform]} className="mx-auto my-8" />
       <Divider direction="horizon" />
       {Others}
+      <MoreButton status={othersState.status} onClick={handleMoreClick(true)} />
     </ul>
   );
 }
@@ -91,10 +96,10 @@ function convertItems() {
 
       if (status === "LOADING_MORE") {
         Items.push(
-          <>
+          <Fragment key="loadingMore">
             <Loading single={single} />
             <Divider direction="horizon" />
-          </>
+          </Fragment>
         );
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.51.5",
+        "swr": "^2.2.5",
         "zustand": "^4.5.2"
       },
       "devDependencies": {
@@ -4868,12 +4869,12 @@
       }
     },
     "node_modules/@storybook/builder-webpack5": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-8.2.7.tgz",
-      "integrity": "sha512-3SWN0X6qB14jnCrpMWd5tCshxzLEcRK5Sw/vBIW9HUsUx9OVMPxWp+Ti6NZHqj6FfHVbJb+qOwHl493JAJaFdg==",
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-8.2.8.tgz",
+      "integrity": "sha512-1eH8OYcsjkFtpodJNsrrgDsR7oDPLpo7FdoF67S9g/mRxTl1RCwhMVdeBHgtfge9kHQ1TlpK9tTXine4G3uA3Q==",
       "dev": true,
       "dependencies": {
-        "@storybook/core-webpack": "8.2.7",
+        "@storybook/core-webpack": "8.2.8",
         "@types/node": "^18.0.0",
         "@types/semver": "^7.3.4",
         "browser-assert": "^1.2.1",
@@ -4906,7 +4907,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.2.7"
+        "storybook": "^8.2.8"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -4915,9 +4916,9 @@
       }
     },
     "node_modules/@storybook/builder-webpack5/node_modules/@types/node": {
-      "version": "18.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.43.tgz",
-      "integrity": "sha512-Mw/YlgXnyJdEwLoFv2dpuJaDFriX+Pc+0qOBJ57jC1H6cDxIj2xc5yUrdtArDVG0m+KV6622a4p2tenEqB3C/g==",
+      "version": "18.19.44",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.44.tgz",
+      "integrity": "sha512-ZsbGerYg72WMXUIE9fYxtvfzLEuq6q8mKERdWFnqTmOvudMxnz+CBNRoOwJ2kNpFOncrKjT1hZwxjlFgQ9qvQA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -4966,15 +4967,15 @@
       }
     },
     "node_modules/@storybook/codemod": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-8.2.7.tgz",
-      "integrity": "sha512-D2sJcZMUO6Y7DNja4LvdT6uBee4bZbQKB904kEG9Kpr0XF20IHAP9BbkfG8HEFaS0GbJwvGvE03Sg+S1y+vO6Q==",
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-8.2.8.tgz",
+      "integrity": "sha512-dqD4j6JTsS8BM2y1yHBIe5fHvsGM08qpJQXkE77aXJIm5UfUeuWC7rY0xAheX3fU5G98l3BJk0ySUGspQL5pNg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.24.4",
         "@babel/types": "^7.24.0",
-        "@storybook/core": "8.2.7",
+        "@storybook/core": "8.2.8",
         "@storybook/csf": "0.1.11",
         "@types/cross-spawn": "^6.0.2",
         "cross-spawn": "^7.0.3",
@@ -5035,22 +5036,22 @@
       }
     },
     "node_modules/@storybook/components": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.2.7.tgz",
-      "integrity": "sha512-FXhnoHl9S+tKSFc62iUG3EWplQP9ojGQaSMhqP4QTus6xmo53oSsPzuTPQilKVHkGxFQW8eGgKKsfHw3G2NT2g==",
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.2.8.tgz",
+      "integrity": "sha512-d4fI7Clogx4rgLAM7vZVr9L2EFtAkGXvpkZFuB0H0eyYaxZSbuZYvDCzRglQGQGsqD8IA8URTgPVSXC3L3k6Bg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.2.7"
+        "storybook": "^8.2.8"
       }
     },
     "node_modules/@storybook/core": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.2.7.tgz",
-      "integrity": "sha512-vgw5MYN9Bq2/ZsObCOEHbBHwi4RpbYCHPFtKkr4kTnWID++FCSiSVd7jY3xPvcNxWqCxOyH6dThpBi+SsB/ZAA==",
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.2.8.tgz",
+      "integrity": "sha512-Wwm/Txh87hbxqU9OaxXwdGAmdRBjDn7rlZEPjNBx0tt43SQ11fKambY7nVWrWuw46YsJpdF9V/PQr4noNEXXEA==",
       "dev": true,
       "dependencies": {
         "@storybook/csf": "0.1.11",
@@ -5198,9 +5199,9 @@
       }
     },
     "node_modules/@storybook/core-webpack": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-8.2.7.tgz",
-      "integrity": "sha512-eVtizQZdjPePjjPBfMw+74ha2yZw68AQZu5TK01Vetdjz1h+SSt+p/otWcJWPMGpZOg9p+n0krWvlcYHBsZsbA==",
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-8.2.8.tgz",
+      "integrity": "sha512-IvrhsDNM/4aTIfUEtYorz9N9S+9gCVkUuUVTNiX0N9a24BFLTcPebtJZYXbguZqxN/NeJMMfk1k7YLU2cBmdjw==",
       "dev": true,
       "dependencies": {
         "@types/node": "^18.0.0",
@@ -5211,22 +5212,22 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.2.7"
+        "storybook": "^8.2.8"
       }
     },
     "node_modules/@storybook/core-webpack/node_modules/@types/node": {
-      "version": "18.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.43.tgz",
-      "integrity": "sha512-Mw/YlgXnyJdEwLoFv2dpuJaDFriX+Pc+0qOBJ57jC1H6cDxIj2xc5yUrdtArDVG0m+KV6622a4p2tenEqB3C/g==",
+      "version": "18.19.44",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.44.tgz",
+      "integrity": "sha512-ZsbGerYg72WMXUIE9fYxtvfzLEuq6q8mKERdWFnqTmOvudMxnz+CBNRoOwJ2kNpFOncrKjT1hZwxjlFgQ9qvQA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
     "node_modules/@storybook/core/node_modules/@types/node": {
-      "version": "18.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.43.tgz",
-      "integrity": "sha512-Mw/YlgXnyJdEwLoFv2dpuJaDFriX+Pc+0qOBJ57jC1H6cDxIj2xc5yUrdtArDVG0m+KV6622a4p2tenEqB3C/g==",
+      "version": "18.19.44",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.44.tgz",
+      "integrity": "sha512-ZsbGerYg72WMXUIE9fYxtvfzLEuq6q8mKERdWFnqTmOvudMxnz+CBNRoOwJ2kNpFOncrKjT1hZwxjlFgQ9qvQA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -5316,22 +5317,22 @@
       }
     },
     "node_modules/@storybook/manager-api": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.2.7.tgz",
-      "integrity": "sha512-BXjz6eNl1GyFcMwzRQTIokslcIY71AYblJUscPcy03X93oqI0GjFVa1xuSMwYw/oXWn7SHhKmqtqEG19lvBGRQ==",
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.2.8.tgz",
+      "integrity": "sha512-wzfRu3vrD9a99pN3W/RJXVtgNGNsy9PyvetjUfgQVtUZ9eXXDuA+tM7ITTu3xvONtV/rT2YEBwzOpowa+r1GNQ==",
       "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.2.7"
+        "storybook": "^8.2.8"
       }
     },
     "node_modules/@storybook/nextjs": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@storybook/nextjs/-/nextjs-8.2.7.tgz",
-      "integrity": "sha512-q3SO8XIHXdHhGRmY8qoVtddIpjBMKh71A//LyZFac77ltgIKx+02vExKMVCtj7h8QcRm86SiobXfTXR7faRDmA==",
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/nextjs/-/nextjs-8.2.8.tgz",
+      "integrity": "sha512-j7ip8JzLGuw1AzRkPZC/dCymYUAj4kVyS3CNmlGEms7h4pAaPr3oTuIRO0AMzRfR3DId4DRho3P4eTLHF5QdIA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
@@ -5348,10 +5349,10 @@
         "@babel/preset-typescript": "^7.24.1",
         "@babel/runtime": "^7.24.4",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
-        "@storybook/builder-webpack5": "8.2.7",
-        "@storybook/preset-react-webpack": "8.2.7",
-        "@storybook/react": "8.2.7",
-        "@storybook/test": "8.2.7",
+        "@storybook/builder-webpack5": "8.2.8",
+        "@storybook/preset-react-webpack": "8.2.8",
+        "@storybook/react": "8.2.8",
+        "@storybook/test": "8.2.8",
         "@types/node": "^18.0.0",
         "@types/semver": "^7.3.4",
         "babel-loader": "^9.1.3",
@@ -5388,7 +5389,7 @@
         "next": "^13.5.0 || ^14.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.2.7",
+        "storybook": "^8.2.8",
         "webpack": "^5.0.0"
       },
       "peerDependenciesMeta": {
@@ -5398,6 +5399,47 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/instrumenter": {
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-8.2.8.tgz",
+      "integrity": "sha512-6Gk3CzoYQQXBXpW86PKqYSozOB/C9dSYiFvwPRo4XsEfjARDi8yglqkbOtG+FVqKDL66I5krcveB8bTWigqc9g==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@vitest/utils": "^1.3.1",
+        "util": "^0.12.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.8"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/test": {
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/test/-/test-8.2.8.tgz",
+      "integrity": "sha512-Lbt4DHP8WhnakTPw981kP85DeoONKN+zVLjFPa5ptllyT+jazZANjIdGhNUlBdIzOw3oyDXhGlWIdtqztS3pSA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/csf": "0.1.11",
+        "@storybook/instrumenter": "8.2.8",
+        "@testing-library/dom": "10.1.0",
+        "@testing-library/jest-dom": "6.4.5",
+        "@testing-library/user-event": "14.5.2",
+        "@vitest/expect": "1.6.0",
+        "@vitest/spy": "1.6.0",
+        "util": "^0.12.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.8"
       }
     },
     "node_modules/@storybook/nextjs/node_modules/@types/node": {
@@ -5432,13 +5474,13 @@
       }
     },
     "node_modules/@storybook/preset-react-webpack": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-8.2.7.tgz",
-      "integrity": "sha512-kJIgSub9wmoQgpLDfDlugK3nXeHL+skzRhUNH1ft80Il79hfQsNg7MLv6fXPvAJbjHYiQubYMwfdL4+Zwajopw==",
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-8.2.8.tgz",
+      "integrity": "sha512-mFeuoKXn2mielz8rix11QcOZr5sNWIIKZ8Le6PG2jPRfLmLWNgL8vJEVPy8y4lWPfzo+Q2tnNefLbMombtga5w==",
       "dev": true,
       "dependencies": {
-        "@storybook/core-webpack": "8.2.7",
-        "@storybook/react": "8.2.7",
+        "@storybook/core-webpack": "8.2.8",
+        "@storybook/react": "8.2.8",
         "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
         "@types/node": "^18.0.0",
         "@types/semver": "^7.3.4",
@@ -5461,7 +5503,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.2.7"
+        "storybook": "^8.2.8"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -5470,9 +5512,9 @@
       }
     },
     "node_modules/@storybook/preset-react-webpack/node_modules/@types/node": {
-      "version": "18.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.43.tgz",
-      "integrity": "sha512-Mw/YlgXnyJdEwLoFv2dpuJaDFriX+Pc+0qOBJ57jC1H6cDxIj2xc5yUrdtArDVG0m+KV6622a4p2tenEqB3C/g==",
+      "version": "18.19.44",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.44.tgz",
+      "integrity": "sha512-ZsbGerYg72WMXUIE9fYxtvfzLEuq6q8mKERdWFnqTmOvudMxnz+CBNRoOwJ2kNpFOncrKjT1hZwxjlFgQ9qvQA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -5491,30 +5533,30 @@
       }
     },
     "node_modules/@storybook/preview-api": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.2.7.tgz",
-      "integrity": "sha512-lNZBTjZaYNSwBY8dEcDZdkOBvq1/JoVWpuvqDEKvGmp5usTe77xAOwGyncEb96Cx1BbXXkMiDrqbV5G23PFRYA==",
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.2.8.tgz",
+      "integrity": "sha512-BDt1lo5oEWAaTVCsl6JUHCBFtIWI/Za4qvIdn2Lx9eCA+Ae6IDliosmu273DcvGD9R4OPF6sm1dML3TXILGGcA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.2.7"
+        "storybook": "^8.2.8"
       }
     },
     "node_modules/@storybook/react": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-8.2.7.tgz",
-      "integrity": "sha512-Qkw1K1iBDk+E9dlHrEWOOkn0trUU6wSt4mvzyOekiApM290esnPtw6GYXvxfBgFwNXfXbaGG3QNYGAFevf7qHw==",
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-8.2.8.tgz",
+      "integrity": "sha512-Nln0DDTQ930P4J+SEkWbLSgaDe8eDd5gP6h3l4b5RwT7sRuSyHtTtYHPCnU9U7sLQ3AbMsclgtJukHXDitlccg==",
       "dev": true,
       "dependencies": {
-        "@storybook/components": "^8.2.7",
+        "@storybook/components": "^8.2.8",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager-api": "^8.2.7",
-        "@storybook/preview-api": "^8.2.7",
-        "@storybook/react-dom-shim": "8.2.7",
-        "@storybook/theming": "^8.2.7",
+        "@storybook/manager-api": "^8.2.8",
+        "@storybook/preview-api": "^8.2.8",
+        "@storybook/react-dom-shim": "8.2.8",
+        "@storybook/theming": "^8.2.8",
         "@types/escodegen": "^0.0.6",
         "@types/estree": "^0.0.51",
         "@types/node": "^18.0.0",
@@ -5541,7 +5583,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.2.7",
+        "storybook": "^8.2.8",
         "typescript": ">= 4.2.x"
       },
       "peerDependenciesMeta": {
@@ -5582,6 +5624,21 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "storybook": "^8.2.7"
+      }
+    },
+    "node_modules/@storybook/react/node_modules/@storybook/react-dom-shim": {
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.2.8.tgz",
+      "integrity": "sha512-2my3dGBOpBe30+FsSdQOIYCfxMyT68+SEq0qcXxfuax0BkhhJnZLpwvpqOna6EOVTgBD+Tk1TKmjpGwxuwp4rg==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "storybook": "^8.2.8"
       }
     },
     "node_modules/@storybook/react/node_modules/@types/node": {
@@ -5665,16 +5722,16 @@
       }
     },
     "node_modules/@storybook/theming": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.2.7.tgz",
-      "integrity": "sha512-+iqm0GfRkshrjjNSOzwl7AD2m+LtJGXJCr93ke1huDK497WUKbX1hbbw51h5E1tEkx0c2wIqUlaqCM+7XMYcpw==",
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.2.8.tgz",
+      "integrity": "sha512-jt5oUO82LN3z5aygNdHucBZcErSicIAwzhR5Kz9E/C9wUbhyZhbWsWyhpZaytu8LJUj2YWAIPS8kq/jGx+qLZA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.2.7"
+        "storybook": "^8.2.8"
       }
     },
     "node_modules/@storybook/types": {
@@ -10337,9 +10394,9 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
-      "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
+      "version": "6.5.6",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.6.tgz",
+      "integrity": "sha512-mpzdtpeCLuS3BmE3pO3Cpp5bbjlOPY2Q0PgoF+Od1XZrHLYI28Xe3ossCmYCQt11FQKEYd9+PF8jymTvtWJSHQ==",
       "dev": true,
       "dependencies": {
         "bn.js": "^4.11.9",
@@ -11954,9 +12011,9 @@
       "dev": true
     },
     "node_modules/flow-parser": {
-      "version": "0.242.1",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.242.1.tgz",
-      "integrity": "sha512-E3ml21Q1S5cMAyPbtYslkvI6yZO5oCS/S2EoteeFH8Kx9iKOv/YOJ+dGd/yMf+H3YKfhMKjnOpyNwrO7NdddWA==",
+      "version": "0.243.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.243.0.tgz",
+      "integrity": "sha512-HCDBfH+kZcY5etWYeAqatjW78gkIryzb9XixRsA8lGI1uyYc7aCpElkkO4H+KIpoyQMiY0VAZPI4cyac3wQe8w==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -20624,15 +20681,15 @@
       }
     },
     "node_modules/storybook": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.2.7.tgz",
-      "integrity": "sha512-Jb9DXue1sr3tKkpuq66VP5ItOKTpxL6t99ze1wXDbjCvPiInTdPA5AyFEjBuKjOBIh28bayYoOZa6/xbMJV+Wg==",
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.2.8.tgz",
+      "integrity": "sha512-sh4CNCXkieVgJ5GXrCOESS0BjRbQ9wG7BVnurQPl6izNnB9zR8rag+aUmjPZWBwbj55V1BFA5A/vEsCov21qjg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/types": "^7.24.0",
-        "@storybook/codemod": "8.2.7",
-        "@storybook/core": "8.2.7",
+        "@storybook/codemod": "8.2.8",
+        "@storybook/core": "8.2.8",
         "@types/semver": "^7.3.4",
         "@yarnpkg/fslib": "2.10.3",
         "@yarnpkg/libzip": "2.3.0",
@@ -21279,6 +21336,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "dependencies": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/tabbable": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.51.5",
+    "swr": "^2.2.5",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -95,13 +95,6 @@ export async function create() {
     .execute();
 
   await db.schema
-    .createIndex("Post_userId_index")
-    .ifNotExists()
-    .on("Post")
-    .column("userId")
-    .execute();
-
-  await db.schema
     .createTable("Comment")
     .ifNotExists()
     .addColumn("id", "uuid", (col) =>
@@ -122,13 +115,6 @@ export async function create() {
     .addColumn("updatedAt", "timestamptz", (col) =>
       col.defaultTo(sql`CURRENT_TIMESTAMP`).notNull()
     )
-    .execute();
-
-  await db.schema
-    .createIndex("Comment_userId_index")
-    .ifNotExists()
-    .on("Comment")
-    .column("userId")
     .execute();
 
   await db.schema

--- a/stories/CommentCreateForm.stories.tsx
+++ b/stories/CommentCreateForm.stories.tsx
@@ -32,7 +32,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const CreationForm: Story = {
-  args: { session: { user: { id: "1" }, expires: "" }, postId: "1" },
+  args: { session: { user: { id: "1" }, expires: "" }, postId: 1 },
   beforeEach: () => {
     const mockResult = new Promise<{ id: string }>((resolve) => {
       resolve({ id: "commentId" });

--- a/stories/PostCreateForm.stories.tsx
+++ b/stories/PostCreateForm.stories.tsx
@@ -35,8 +35,8 @@ type Story = StoryObj<typeof meta>;
 export const CreationForm: Story = {
   args: {},
   beforeEach: async () => {
-    const mockResult = new Promise<{ id: string }>((resolve) => {
-      resolve({ id: "postId" });
+    const mockResult = new Promise<{ id: number }>((resolve) => {
+      resolve({ id: 1 });
     });
     createPost.mockReturnValue(mockResult);
   },
@@ -108,7 +108,7 @@ export const CreationForm: Story = {
 
 export const UpdateForm: Story = {
   args: {
-    id: "1",
+    id: 1,
     content: "1234567890abcdefghijㄱㄴㄷㄹㅁㅂㅅㅇㅈㅊ",
     etcPlatformName: null,
     images: [],
@@ -126,7 +126,7 @@ export const UpdateForm: Story = {
 
     const mockGetResult = new Promise<PostInfo>((resolve) => {
       resolve({
-        id: "1",
+        id: 1,
         userId: "1",
         content: "1234567890abcdefghijㄱㄴㄷㄹㅁㅂㅅㅇㅈㅊ",
         etcPlatformName: null,


### PR DESCRIPTION
# 구현 내용
- 무한 스크롤을 구현합니다.
  - 클라이언트 측 페이지네이션 패칭을 관리하기 위해 SWR를 설치합니다.
  - 번들 사이즈 기준 react-query에 비해 3배 가벼운 점이 주요 선택 이유입니다.
    - 첫 로딩에 보여지는 메인 페이지에 사용되며 무한 스크롤 이외에 클라이언트 패칭이 사용되는 곳이 없을 것으로 예상 중입니다.
  - DB query를 페이지네이션에 호환되도록 `Post.id`를 number 타입으로 수정합니다.
  - 또한 커서를 포함한 `where` 절과 `limit`절을 추가하여 keyset pagenation으로 구현합니다.
  - api도 페이지네이션에 호환되도록 반환값을 구성합니다.
    - 필요한 필터 및 커서 데이터는 query string 형태로 가져옵니다.
  - 목록 컨테이너 Ref에 접근하는 기능을 위해 Context로 목록 조작 기능을 전달합니다.
  - `useSWRInfinite`을 이용한 패칭 로직은 `useInfiniteSearch`훅으로 분리하여 사용합니다.
  - 목록에 더보기 버튼을 추가하여 항목이 10개를 넘을 때 개수를 제한합니다.
- 목록 방향키 인터렉션을 추가합니다.
  - 검색창에 포커스가 있을 때 상하 방향키와 엔터로 목록을 선택할 수 있습니다. 
  - 화면 밖 항복이 활성화되면 뷰포트에 보이도록 스크롤을 이동합니다.
- DB 인덱스 정리
  - 인덱스에 대한 이해 부족으로 과하게 설정했던 인덱스를 삭제합니다.
  - join절의 성능을 위해 `Comment.postId` 인덱스를 추가합니다.

# 이슈 번호
- close #45 