### PR TITLE
폼 아이템 컴포넌트 색상 의존성 제거

### DIFF
--- a/app/post/create/form.tsx
+++ b/app/post/create/form.tsx
@@ -150,6 +150,7 @@ export default function PostForm({
                 <Label color={color}>거래 사이트</Label>
                 <Select
                   options={platformOptions}
+                  color={color}
                   className="block"
                   {...register("platform", {
                     onChange: handleSelectChange,
@@ -160,7 +161,11 @@ export default function PostForm({
               {platform === "etc" && (
                 <Field className="mt-2 flex flex-col">
                   <Label color={color}>사이트 이름</Label>
-                  <Input type="text" {...register("etcPlatformName")} />
+                  <Input
+                    color={color}
+                    type="text"
+                    {...register("etcPlatformName")}
+                  />
                   <ErrorMessage
                     name="etcPlatformName"
                     errors={errors}
@@ -173,6 +178,7 @@ export default function PostForm({
               <Field className="flex flex-col">
                 <Label color={color}>상대 닉네임</Label>
                 <Input
+                  color={color}
                   type="text"
                   className="block w-full"
                   {...register("targetNickname")}
@@ -191,6 +197,7 @@ export default function PostForm({
                   </HelpCircle>
                 </Label>
                 <Input
+                  color={color}
                   type="text"
                   placeholder={PLATFORM_PLACEHOLDER[platform]}
                   {...register("additionalInfo")}
@@ -210,6 +217,7 @@ export default function PostForm({
               name="tag"
               render={({ field }) => (
                 <RadioTabs<TagId>
+                  color={color}
                   name="tag"
                   defaultValue={isUpdate ? defaultValues.tag : "others"}
                   onChange={field.onChange}

--- a/app/ui/formItems/Input.tsx
+++ b/app/ui/formItems/Input.tsx
@@ -1,22 +1,21 @@
-"use client";
-
 import { Input as HeadlessInput } from "@headlessui/react";
 import React from "react";
 
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
-import type { Platform } from "#lib/types/property.js";
+import type { FormColor } from "#lib/types/property.js";
 
-interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  color: FormColor;
+}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className = "", ...props }, ref) => {
-    const platform = usePlatformStore((store) => store.platform);
-
-    const platformStyles: { [key in Platform]: string } = {
-      daangn: "border-orange-500 focus:outline-orange-400",
-      bunjang: "border-red-500 focus:outline-red-400",
-      joongna: "border-green-500 focus:outline-green-400",
-      etc: "border-zinc-500 focus:outline-zinc-400",
+  ({ color, className = "", ...props }, ref) => {
+    const colorStyles: { [key in FormColor]: string } = {
+      orange: "border-orange-500 focus:outline-orange-400",
+      red: "border-red-500 focus:outline-red-400",
+      green: "border-green-500 focus:outline-green-400",
+      zinc: "border-zinc-500 focus:outline-zinc-400",
+      rose: "border-rose-500 focus:outline-rose-400",
+      lime: "border-lime-500 focus:outline-lime-400",
     };
 
     const inputDefaultStyle = "h-8 min-w-32 rounded border px-2";
@@ -24,7 +23,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     return (
       <HeadlessInput
         ref={ref}
-        className={`${inputDefaultStyle} ${platformStyles[platform]} ${className}`}
+        className={`${inputDefaultStyle} ${colorStyles[color]} ${className}`}
         {...props}
       />
     );

--- a/app/ui/formItems/RadioTabs.tsx
+++ b/app/ui/formItems/RadioTabs.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
   Description,
   Field,
@@ -9,58 +7,64 @@ import {
 } from "@headlessui/react";
 import React from "react";
 
-import { PLATFORM_COLOR } from "#lib/constants/platform.js";
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
-import type { Platform } from "#lib/types/property.js";
+import type { FormColor } from "#lib/types/property.js";
 import Label from "#ui/formItems/Label.jsx";
 
 interface RadioTabsProps<ItemType extends string>
   extends RadioGroupProps<"div", ItemType> {
   items: { id: ItemType; name: string; description: string }[];
+  color: FormColor;
 }
 
 function RadioTabs<ItemType extends string>({
   items,
+  color,
   className = "",
   ...props
 }: RadioTabsProps<ItemType>) {
-  const platform = usePlatformStore((store) => store.platform);
-
   const defaultStyle =
     "grid grid-cols-autofit-48 gap-3 box-border cursor-pointer";
   const itemDefaultStyle = "rounded-md border";
   const labelDefaultStyle =
     "rounded-tl-md rounded-br-md py-1 px-2 border inline-block cursor-pointer";
 
-  const platformStyles: { [key in Platform]: string } = {
-    daangn: "border-orange-400",
-    bunjang: "border-red-400",
-    joongna: "border-green-400",
-    etc: "border-zinc-400",
+  const colorStyles: { [key in FormColor]: string } = {
+    orange: "border-orange-400",
+    red: "border-red-400",
+    green: "border-green-400",
+    zinc: "border-zinc-400",
+    rose: "border-rose-400",
+    lime: "border-lime-400",
   };
 
-  const platformCheckedStyles: (checked: boolean) => {
-    [key in Platform]: string;
+  const colorCheckedStyles: (checked: boolean) => {
+    [key in FormColor]: string;
   } = (checked) => ({
-    daangn: checked
+    orange: checked
       ? "bg-orange-300 hover:bg-orange-200"
       : "bg-orange-50 hover:bg-orange-100",
-    bunjang: checked
-      ? "bg-red-300 hover:bg-red-200"
-      : "bg-red-50 hover:bg-red-100",
-    joongna: checked
+    red: checked ? "bg-red-300 hover:bg-red-200" : "bg-red-50 hover:bg-red-100",
+    green: checked
       ? "bg-green-300 hover:bg-green-200"
       : "bg-green-50 hover:bg-green-100",
-    etc: checked
+    zinc: checked
       ? "bg-zinc-300 hover:bg-zinc-200"
       : "bg-zinc-50 hover:bg-zinc-100",
+    rose: checked
+      ? "bg-rose-300 hover:bg-rose-200"
+      : "bg-rose-50 hover:bg-rose-100",
+    lime: checked
+      ? "bg-lime-300 hover:bg-lime-200"
+      : "bg-lime-50 hover:bg-lime-100",
   });
 
-  const platformLabelStyles: { [key in Platform]: string } = {
-    daangn: "bg-orange-100 border-orange-400",
-    bunjang: "bg-red-100 border-red-400",
-    joongna: "bg-green-100 border-green-400",
-    etc: "bg-zinc-100 border-zinc-400",
+  const colorLabelStyles: { [key in FormColor]: string } = {
+    orange: "bg-orange-100 border-orange-400",
+    red: "bg-red-100 border-red-400",
+    green: "bg-green-100 border-green-400",
+    zinc: "bg-zinc-100 border-zinc-400",
+    rose: "bg-rose-100 border-rose-400",
+    lime: "bg-lime-100 border-lime-400",
   };
 
   return (
@@ -70,11 +74,11 @@ function RadioTabs<ItemType extends string>({
           <Radio value={id}>
             {({ checked }) => (
               <div
-                className={`${itemDefaultStyle} ${platformStyles[platform]} ${platformCheckedStyles(checked)[platform]}`}>
+                className={`${itemDefaultStyle} ${colorStyles[color]} ${colorCheckedStyles(checked)[color]}`}>
                 <Label
-                  color={PLATFORM_COLOR[platform]}
+                  color={color}
                   size="md"
-                  className={`${labelDefaultStyle} ${platformLabelStyles[platform]}`}>
+                  className={`${labelDefaultStyle} ${colorLabelStyles[color]}`}>
                   {name}
                 </Label>
                 <Description className={`mx-3 my-2 text-sm text-neutral-700`}>

--- a/app/ui/formItems/Select.tsx
+++ b/app/ui/formItems/Select.tsx
@@ -1,24 +1,22 @@
-"use client";
-
 import { Select as HeadlessSelect } from "@headlessui/react";
 import React, { SelectHTMLAttributes } from "react";
 
-import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
-import type { Platform } from "#lib/types/property.js";
+import type { FormColor } from "#lib/types/property.js";
 
 interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   options: { value: string; name: string }[];
+  color: FormColor;
 }
 
 const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
-  ({ options, className = "", ...props }, ref) => {
-    const platform = usePlatformStore((store) => store.platform);
-
-    const platformStyles: { [key in Platform]: string } = {
-      daangn: "border-orange-500 focus:outline-orange-400",
-      bunjang: "border-red-500 focus:outline-red-400",
-      joongna: "border-green-500 focus:outline-green-400",
-      etc: "border-zinc-500 focus:outline-zinc-400",
+  ({ options, color, className = "", ...props }, ref) => {
+    const colorStyles: { [key in FormColor]: string } = {
+      orange: "border-orange-500 focus:outline-orange-400",
+      red: "border-red-500 focus:outline-red-400",
+      green: "border-green-500 focus:outline-green-400",
+      zinc: "border-zinc-500 focus:outline-zinc-400",
+      rose: "border-rose-500 focus:outline-rose-400",
+      lime: "border-lime-500 focus:outline-lime-400",
     };
 
     const defaultStyle = "h-8 min-w-32 rounded border px-2";
@@ -26,8 +24,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     return (
       <HeadlessSelect
         ref={ref}
-        value={platform}
-        className={`${defaultStyle} ${platformStyles[platform]} ${className}`}
+        className={`${defaultStyle} ${colorStyles[color]} ${className}`}
         {...props}>
         {options.map(({ value, name }) => (
           <option key={name} value={value}>


### PR DESCRIPTION
# 구현 내용
- 일부 폼 아이템 컴포넌트에서 색상을 `platform`에 따라 설정하고 있던 것을 `color`인수로 받도록 수정합니다.
- 포스트 작성 form에 수정을 반영합니다.

# 이슈 번호
- close #57 