### PR TITLE
반박 댓글 임시저장 기능 적용

### DIFF
--- a/app/lib/utils/supabase/images.ts
+++ b/app/lib/utils/supabase/images.ts
@@ -1,7 +1,7 @@
-import type { Session } from "next-auth";
-
 import type { FormValues } from "#lib/actions/post/createPostAction.js";
 import { createClient } from "#lib/utils/supabase/server.js";
+
+const STORAGE_ID = "patda-images";
 
 export async function moveImages(
   images: FormValues["images"],
@@ -11,7 +11,7 @@ export async function moveImages(
   const supabase = createClient();
   const promises = images.map(async ({ name }) => {
     const { data, error } = await supabase.storage
-      .from("patda-images")
+      .from(STORAGE_ID)
       .move(`${from}/${name}`, `${to}/${name}`);
   });
 
@@ -22,7 +22,7 @@ export async function removeImages(folder: string, imagesToRemain?: string[]) {
   const supabase = createClient();
 
   const { data: listData, error: listError } = await supabase.storage
-    .from("patda-images")
+    .from(STORAGE_ID)
     .list(folder);
   if (!listData) return;
 
@@ -31,6 +31,6 @@ export async function removeImages(folder: string, imagesToRemain?: string[]) {
     .map(({ name }) => `${folder}/${name}`);
 
   const { data, error } = await supabase.storage
-    .from("patda-images")
+    .from(STORAGE_ID)
     .remove(imagePathesToDelete);
 }

--- a/app/post/[id]/(comment)/form.tsx
+++ b/app/post/[id]/(comment)/form.tsx
@@ -11,6 +11,7 @@ import {
   createCommentAction,
 } from "#lib/actions/comment/createCommentAction.js";
 import { useFormAction } from "#lib/hooks/useFormAction.js";
+import useTempSave from "#lib/hooks/useTempSave.js";
 import { useCommentStatusStore } from "#lib/providers/CommentStatusStoreProvider.jsx";
 import { ImageFormProvider } from "#lib/providers/ImageFormProvider.jsx";
 import Dot from "#ui/Dot/Dot.jsx";
@@ -24,6 +25,8 @@ import {
 } from "#ui/formItems/index.jsx";
 import ImageFields from "#ui/ImageForm/ImageFields.jsx";
 import ImageForm from "#ui/ImageForm/ImageForm.jsx";
+import TempSaveButton from "#ui/TempSave/TempSaveButton.jsx";
+import TempSaveList from "#ui/TempSave/TempSaveList.jsx";
 import { cn } from "#utils/utils.js";
 
 const defaultValues: CommentFormValues = {
@@ -56,6 +59,8 @@ export default function CommentForm({
     formState: { errors },
     formAction,
     state,
+    reset,
+    getValues,
   } = useFormAction<CommentFormValues>({
     action: createCommentAction.bind(null, postId),
     onSuccess,
@@ -84,6 +89,32 @@ export default function CommentForm({
       ? "위 논란의 당사자로서 반박할 사항이 있다면 작성해주세요. 작성 시 게시글의 상태가 변경됩니다."
       : "반박 이외의 간단한 댓글을 작성해주세요."
     : `${isDebate ? "반박" : "댓글"}은 로그인 후 작성할 수 있습니다.`;
+
+  const onTempSaveSelect = useCallback(
+    (data: any) => {
+      reset(data);
+    },
+    [reset]
+  );
+
+  const {
+    tempSaveIdx,
+    tempSaveList,
+    tempSaveEnabled,
+    saveData,
+    selectTempSave,
+    deleteTempSave,
+  } = useTempSave({
+    containerId: imagePath,
+    multiSaveEnabled: true,
+    onSelect: onTempSaveSelect,
+  });
+
+  const handleSaveClick = () => {
+    const formValues = getValues();
+    const valuesWithDate = { updatedAt: new Date(), ...formValues };
+    return saveData(valuesWithDate);
+  };
 
   return (
     <ImageFormProvider
@@ -158,13 +189,28 @@ export default function CommentForm({
             (state.status === "ERROR_DATABASE" && (
               <ErrorText>{state.message}</ErrorText>
             ))}
-          <div className="flex justify-end max-sm:px-3">
-            <SubmitButton
-              colorStyle={color}
-              className="ml-auto transition-colors">
+          <div className="flex justify-end gap-6 max-sm:px-3">
+            {isDebate && (
+              <TempSaveButton
+                colorStyle={color}
+                onSaveClick={handleSaveClick}
+              />
+            )}
+            <SubmitButton colorStyle={color} className="transition-colors">
               작성
             </SubmitButton>
           </div>
+          {isDebate && tempSaveEnabled && tempSaveList.length > 0 && (
+            <TempSaveList
+              colorStyle={color}
+              tempSaveIdx={tempSaveIdx}
+              tempSaveList={tempSaveList}
+              titleKey="content"
+              selectTempSave={selectTempSave}
+              deleteTempSave={deleteTempSave}
+              className="mb-3 mt-6 h-11"
+            />
+          )}
         </Fieldset>
       </form>
       <ImageForm />

--- a/app/post/[id]/(comment)/form.tsx
+++ b/app/post/[id]/(comment)/form.tsx
@@ -64,7 +64,9 @@ export default function CommentForm({
   } = useFormAction<CommentFormValues>({
     action: createCommentAction.bind(null, postId),
     onSuccess,
-    defaultValues,
+    useFormProps: {
+      defaultValues,
+    },
   });
 
   const imageArrayRegister = useCallback(

--- a/app/post/[id]/(comment)/form.tsx
+++ b/app/post/[id]/(comment)/form.tsx
@@ -100,7 +100,7 @@ export default function CommentForm({
   );
 
   const {
-    tempSaveIdx,
+    tempSaveKey,
     tempSaveList,
     tempSaveEnabled,
     saveData,
@@ -108,7 +108,6 @@ export default function CommentForm({
     deleteTempSave,
   } = useTempSave({
     containerId: imagePath,
-    multiSaveEnabled: true,
     onSelect: onTempSaveSelect,
   });
 
@@ -205,7 +204,7 @@ export default function CommentForm({
           {isDebate && tempSaveEnabled && tempSaveList.length > 0 && (
             <TempSaveList
               colorStyle={color}
-              tempSaveIdx={tempSaveIdx}
+              tempSaveKey={tempSaveKey}
               tempSaveList={tempSaveList}
               titleKey="content"
               selectTempSave={selectTempSave}

--- a/app/post/[id]/(comment)/form.tsx
+++ b/app/post/[id]/(comment)/form.tsx
@@ -3,7 +3,7 @@
 import { Field, Fieldset } from "@headlessui/react";
 import { ErrorMessage } from "@hookform/error-message";
 import { useRouter } from "next/navigation";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useFieldArray } from "react-hook-form";
 
 import {
@@ -50,9 +50,13 @@ export default function CommentForm({
   );
   const router = useRouter();
 
+  const deleteSuccessTempSave = useRef(() => {});
   const onSuccess = useCallback(() => {
+    deleteSuccessTempSave.current();
+
     router.refresh();
   }, [router]);
+
   const {
     register,
     control,
@@ -110,6 +114,12 @@ export default function CommentForm({
     containerId: imagePath,
     onSelect: onTempSaveSelect,
   });
+
+  deleteSuccessTempSave.current = useCallback(() => {
+    if (tempSaveKey) {
+      deleteTempSave(tempSaveKey);
+    }
+  }, [deleteTempSave, tempSaveKey]);
 
   const handleSaveClick = () => {
     const formValues = getValues();

--- a/app/post/[id]/(comment)/form.tsx
+++ b/app/post/[id]/(comment)/form.tsx
@@ -208,7 +208,7 @@ export default function CommentForm({
               titleKey="content"
               selectTempSave={selectTempSave}
               deleteTempSave={deleteTempSave}
-              className="mb-3 mt-6 h-11"
+              className="relative z-10 mb-5 mt-4 h-11"
             />
           )}
         </Fieldset>

--- a/app/post/create/form.tsx
+++ b/app/post/create/form.tsx
@@ -3,7 +3,7 @@
 import { Field, Fieldset } from "@headlessui/react";
 import { ErrorMessage } from "@hookform/error-message";
 import { useRouter } from "next/navigation";
-import { ChangeEvent, useCallback } from "react";
+import { ChangeEvent, useCallback, useRef } from "react";
 import { Controller, useFieldArray, type UseFormProps } from "react-hook-form";
 
 import {
@@ -82,8 +82,11 @@ export default function PostForm({
 
   const color = PLATFORM_COLOR[platform];
 
+  const deleteSuccessTempSave = useRef(() => {});
   const onSuccess: OnSuccess = useCallback(
     (state) => {
+      deleteSuccessTempSave.current();
+
       const postId = isUpdate ? id : state.resultId;
       router.push(`/post/${postId}`);
     },
@@ -153,6 +156,12 @@ export default function PostForm({
     containerId: imagePath,
     onSelect: onTempSaveSelect,
   });
+
+  deleteSuccessTempSave.current = useCallback(() => {
+    if (tempSaveKey) {
+      deleteTempSave(tempSaveKey);
+    }
+  }, [deleteTempSave, tempSaveKey]);
 
   const handleSaveClick = () => {
     const formValues = getValues();

--- a/app/post/create/form.tsx
+++ b/app/post/create/form.tsx
@@ -178,6 +178,9 @@ export default function PostForm({
                 colorStyle={color}
                 tempSaveIdx={tempSaveIdx}
                 tempSaveList={tempSaveList}
+                categoryKey="platform"
+                categoryValues={PLATFORM_NAME}
+                titleKey="targetNickname"
                 selectTempSave={selectTempSave}
                 deleteTempSave={deleteTempSave}
                 className={cn(

--- a/app/post/create/form.tsx
+++ b/app/post/create/form.tsx
@@ -142,7 +142,7 @@ export default function PostForm({
   );
 
   const {
-    tempSaveIdx,
+    tempSaveKey,
     tempSaveList,
     tempSaveEnabled,
     tempSaveVisible,
@@ -151,7 +151,6 @@ export default function PostForm({
     deleteTempSave,
   } = useTempSave({
     containerId: imagePath,
-    multiSaveEnabled: true,
     onSelect: onTempSaveSelect,
   });
 
@@ -176,7 +175,7 @@ export default function PostForm({
             {tempSaveEnabled && tempSaveList.length > 0 && (
               <TempSaveList
                 colorStyle={color}
-                tempSaveIdx={tempSaveIdx}
+                tempSaveKey={tempSaveKey}
                 tempSaveList={tempSaveList}
                 categoryKey="platform"
                 categoryValues={PLATFORM_NAME}

--- a/app/ui/TempSave/TempSaveList.tsx
+++ b/app/ui/TempSave/TempSaveList.tsx
@@ -33,17 +33,17 @@ const tempSaveListVariants = cva(
 interface TempSaveListProps
   extends ComponentPropsWithRef<"div">,
     VariantProps<typeof tempSaveListVariants> {
-  tempSaveIdx: number | undefined;
+  tempSaveKey: string | undefined;
   tempSaveList: any[];
   categoryKey?: string;
   categoryValues?: { [key: string]: string };
   titleKey?: string;
-  selectTempSave: (idx: number) => void;
-  deleteTempSave: (idx: number) => void;
+  selectTempSave: (key: string) => void;
+  deleteTempSave: (key: string) => void;
 }
 
 export default function TempSaveList({
-  tempSaveIdx,
+  tempSaveKey,
   tempSaveList,
   categoryKey,
   categoryValues,
@@ -54,29 +54,29 @@ export default function TempSaveList({
   className,
   ...props
 }: TempSaveListProps) {
-  const [targetItemIdx, setTargetItemIdx] = useState<number | null>(null);
+  const [targetItemKey, setTargetItemKey] = useState<string | null>(null);
 
   const handleButtonClick = () => {
-    setTargetItemIdx(null);
+    setTargetItemKey(null);
   };
 
   const handleItemClick =
-    (idx: number, itemStatus?: TempSaveItemStatus) =>
+    (key: string, itemStatus?: TempSaveItemStatus) =>
     (e: MouseEvent<HTMLElement>) => {
       e.stopPropagation();
 
-      if (targetItemIdx !== idx) {
-        setTargetItemIdx(idx);
+      if (targetItemKey !== key) {
+        setTargetItemKey(key);
         return;
       }
 
       if (itemStatus === "select") {
-        selectTempSave(idx);
+        selectTempSave(key);
       } else if (itemStatus === "delete") {
-        deleteTempSave(idx);
+        deleteTempSave(key);
       }
 
-      setTargetItemIdx(null);
+      setTargetItemKey(null);
     };
 
   return (
@@ -96,7 +96,7 @@ export default function TempSaveList({
         as="ul"
         transition
         className="origin-top transition ease-out data-[closed]:-translate-y-6 data-[closed]:opacity-0">
-        {tempSaveList.map(({ key, data }, idx) => {
+        {tempSaveList.map(({ key, data }) => {
           const category =
             categoryKey &&
             (categoryValues
@@ -113,10 +113,10 @@ export default function TempSaveList({
               category={category}
               titleText={titleText}
               updatedAt={data.updatedAt}
-              isActive={tempSaveIdx === idx}
-              isTarget={targetItemIdx == idx}
+              isActive={tempSaveKey === key}
+              isTarget={targetItemKey == key}
               colorStyle={itemColorStyle}
-              handleItemClick={handleItemClick.bind(null, idx)}
+              handleItemClick={handleItemClick.bind(null, key)}
             />
           );
         })}

--- a/app/ui/TempSave/TempSaveList.tsx
+++ b/app/ui/TempSave/TempSaveList.tsx
@@ -5,7 +5,8 @@ import { FaChevronDown } from "@react-icons/all-files/fa/FaChevronDown";
 import { cva, type VariantProps } from "class-variance-authority";
 import { type ComponentPropsWithRef, type MouseEvent, useState } from "react";
 
-import type { TempSaveItemStatus } from "#lib/types/property.js";
+import { PLATFORM_COLOR } from "#lib/constants/platform.js";
+import type { Platform, TempSaveItemStatus } from "#lib/types/property.js";
 import Label from "#ui/formItems/Label.jsx";
 import TempSaveListItem from "#ui/TempSave/TempSaveListItem.jsx";
 import { cn } from "#utils/utils.js";
@@ -34,6 +35,9 @@ interface TempSaveListProps
     VariantProps<typeof tempSaveListVariants> {
   tempSaveIdx: number | undefined;
   tempSaveList: any[];
+  categoryKey?: string;
+  categoryValues?: { [key: string]: string };
+  titleKey?: string;
   selectTempSave: (idx: number) => void;
   deleteTempSave: (idx: number) => void;
 }
@@ -41,6 +45,9 @@ interface TempSaveListProps
 export default function TempSaveList({
   tempSaveIdx,
   tempSaveList,
+  categoryKey,
+  categoryValues,
+  titleKey,
   selectTempSave,
   deleteTempSave,
   colorStyle,
@@ -89,17 +96,30 @@ export default function TempSaveList({
         as="ul"
         transition
         className="origin-top transition ease-out data-[closed]:-translate-y-6 data-[closed]:opacity-0">
-        {tempSaveList.map(({ key, data }, idx) => (
-          <TempSaveListItem
-            key={key}
-            platform={data.platform}
-            targetNickname={data.targetNickname}
-            updatedAt={data.updatedAt}
-            isActive={tempSaveIdx === idx}
-            isTarget={targetItemIdx == idx}
-            handleItemClick={handleItemClick.bind(null, idx)}
-          />
-        ))}
+        {tempSaveList.map(({ key, data }, idx) => {
+          const category =
+            categoryKey &&
+            (categoryValues
+              ? categoryValues[data[categoryKey]]
+              : data[categoryKey]);
+          const titleText = titleKey && data[titleKey];
+          const itemColorStyle = data.platform
+            ? PLATFORM_COLOR[data.platform as Platform]
+            : colorStyle;
+
+          return (
+            <TempSaveListItem
+              key={key}
+              category={category}
+              titleText={titleText}
+              updatedAt={data.updatedAt}
+              isActive={tempSaveIdx === idx}
+              isTarget={targetItemIdx == idx}
+              colorStyle={itemColorStyle}
+              handleItemClick={handleItemClick.bind(null, idx)}
+            />
+          );
+        })}
       </PopoverPanel>
     </Popover>
   );

--- a/app/ui/TempSave/TempSaveListItem.tsx
+++ b/app/ui/TempSave/TempSaveListItem.tsx
@@ -93,7 +93,7 @@ export default function TempSaveListItem({
           size={isActive ? "md" : "sm"}
           className={cn("transition-all", isActive && "border-4")}
         />
-        {titleText || ""}
+        <h1 className="min-w-0 max-w-[50%] truncate">{titleText || ""}</h1>
       </div>
       <div
         className={cn(

--- a/app/ui/TempSave/TempSaveListItem.tsx
+++ b/app/ui/TempSave/TempSaveListItem.tsx
@@ -5,7 +5,11 @@ import { cva } from "class-variance-authority";
 import { type ComponentProps, type MouseEvent, useState } from "react";
 
 import { PLATFORM_COLOR, PLATFORM_NAME } from "#lib/constants/platform.js";
-import type { Platform, TempSaveItemStatus } from "#lib/types/property.js";
+import type {
+  FormColor,
+  Platform,
+  TempSaveItemStatus,
+} from "#lib/types/property.js";
 import AuthorTag from "#ui/AuthorTag/AuthorTag.jsx";
 import Dot from "#ui/Dot/Dot.jsx";
 import Label from "#ui/formItems/Label.jsx";
@@ -13,7 +17,7 @@ import Spotlight from "#ui/TempSave/Spotlight.jsx";
 import { cn } from "#utils/utils.js";
 
 const tempSaveListItemVariants = cva(
-  "relative flex cursor-pointer items-center justify-between overflow-hidden rounded border-t px-3 py-2 shadow",
+  "relative flex min-h-11 cursor-pointer items-center justify-between overflow-hidden rounded border-t px-3 py-2 shadow",
   {
     variants: {
       colorStyle: {
@@ -34,28 +38,28 @@ const tempSaveListItemVariants = cva(
 );
 
 interface TempSaveListItemProps extends ComponentProps<"li"> {
-  platform: Platform;
-  targetNickname: string;
   updatedAt: Date;
   isActive: boolean;
   isTarget: boolean;
+  category?: string | false;
+  titleText?: string | false;
+  colorStyle?: FormColor | null;
   handleItemClick: (
     itemStatus?: TempSaveItemStatus
   ) => (e: MouseEvent<HTMLElement>) => void;
 }
 
 export default function TempSaveListItem({
-  platform,
-  targetNickname,
   updatedAt,
   isActive,
   isTarget,
+  category,
+  titleText,
+  colorStyle,
   handleItemClick,
   className,
   ...props
 }: TempSaveListItemProps) {
-  const colorStyle = PLATFORM_COLOR[platform];
-
   const [itemStatus, setItemStatus] = useState<TempSaveItemStatus>("select");
 
   const handleItemClickWithStatus = (itemStatus?: TempSaveItemStatus) => {
@@ -82,14 +86,14 @@ export default function TempSaveListItem({
       {...props}>
       <div className="flex items-center gap-2">
         <Label colorStyle={colorStyle} size="md">
-          {PLATFORM_NAME[platform]}
+          {category || ""}
         </Label>
         <Dot
           colorStyle={colorStyle}
           size={isActive ? "md" : "sm"}
           className={cn("transition-all", isActive && "border-4")}
         />
-        {targetNickname}
+        {titleText || ""}
       </div>
       <div
         className={cn(


### PR DESCRIPTION
# 구현 내용
- 반박용 댓글에도 임시저장 기능을 적용
  - `TempSaveListItem`에 표시되는 내용을 범용적으로 사용할 수 있도록 props 수정
  - 기존 `platform`과 `targetNickname`이던 속성을 `category`와 `title`로 변경
  - `category`는 객체의 키로 사용할 수 있도록 선택적 속성인 `categoryValues` 속성을 추가
  - 댓글에는 카테고리 없이 title로 `content`를 사용
    - 일정 길이 이상일 시 elipsis 적용
- 댓글 폼 reset 방식 수정
  - `useForm`에 defaultValues를 지정하지 않아 reset이 제대로 적용되지 않았던 상황
  - 기존에 따로 `useFormAction`에 전달하던 초기화용 defaultValues 삭제.
- 임시 저장 리스트 선택 및 관리 기준 기존 idx에서 key 속성으로 변경
  - 기존 idx는 삭제 및 추가 시 로직 오류
- 임시 저장 기반 폼 제출 시 해당 임시 저장 자동 삭제

# 이슈 번호
- close #64 
