### PR TITLE
post/id readFile 제거

### DIFF
--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -15,10 +15,10 @@ export const contentType = "image/png";
 
 export default async function Image() {
   const fontData = readFile(
-    join(process.cwd(), "public/subset-SANGJUHaerye.woff")
+    join(process.cwd(), "public", "subset-SANGJUHaerye.woff")
   );
 
-  const bgData = await readFile(join(process.cwd(), "public/patda_og.jpg"));
+  const bgData = await readFile(join(process.cwd(), "public", "patda_og.jpg"));
   const bgSrc = Uint8Array.from(bgData).buffer;
 
   return new ImageResponse(<OgImage src={bgSrc} />, {

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -15,10 +15,10 @@ export const contentType = "image/png";
 
 export default async function Image() {
   const fontData = readFile(
-    join(process.cwd(), "./public/subset-SANGJUHaerye.woff")
+    join(process.cwd(), "public/subset-SANGJUHaerye.woff")
   );
 
-  const bgData = await readFile(join(process.cwd(), "./public/patda_og.jpg"));
+  const bgData = await readFile(join(process.cwd(), "public/patda_og.jpg"));
   const bgSrc = Uint8Array.from(bgData).buffer;
 
   return new ImageResponse(<OgImage src={bgSrc} />, {

--- a/app/post/[id]/opengraph-image.tsx
+++ b/app/post/[id]/opengraph-image.tsx
@@ -19,12 +19,12 @@ export default async function Image({ params }: { params: { id: string } }) {
   const postId = params.id;
 
   const fontData = readFile(
-    join(process.cwd(), "./public/subset-SANGJUHaerye.woff")
+    join(process.cwd(), "public/subset-SANGJUHaerye.woff")
   );
 
   const [postData, bgData] = await Promise.all([
     sql`SELECT "targetNickname", platform, "etcPlatformName" FROM "Post" WHERE id = ${postId};`,
-    readFile(join(process.cwd(), "./public/patda_og.jpg")),
+    readFile(join(process.cwd(), "public/patda_og.jpg")),
   ]);
 
   const bgSrc = Uint8Array.from(bgData).buffer;

--- a/app/post/[id]/opengraph-image.tsx
+++ b/app/post/[id]/opengraph-image.tsx
@@ -19,12 +19,12 @@ export default async function Image({ params }: { params: { id: string } }) {
   const postId = params.id;
 
   const fontData = readFile(
-    join(process.cwd(), "public/subset-SANGJUHaerye.woff")
+    join(process.cwd(), "public", "subset-SANGJUHaerye.woff")
   );
 
   const [postData, bgData] = await Promise.all([
     sql`SELECT "targetNickname", platform, "etcPlatformName" FROM "Post" WHERE id = ${postId};`,
-    readFile(join(process.cwd(), "public/patda_og.jpg")),
+    readFile(join(process.cwd(), "public", "patda_og.jpg")),
   ]);
 
   const bgSrc = Uint8Array.from(bgData).buffer;

--- a/app/post/[id]/opengraph-image.tsx
+++ b/app/post/[id]/opengraph-image.tsx
@@ -1,6 +1,3 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
-
 import { sql } from "@vercel/postgres";
 import { ImageResponse } from "next/og";
 
@@ -18,16 +15,17 @@ export const contentType = "image/png";
 export default async function Image({ params }: { params: { id: string } }) {
   const postId = params.id;
 
-  const fontData = readFile(
-    join(process.cwd(), "public", "subset-SANGJUHaerye.woff")
-  );
+  const fontData = fetch(
+    new URL("subset-SANGJUHaerye.woff", process.env.PATDA_PROJECT_URL)
+  ).then((res) => res.arrayBuffer());
 
-  const [postData, bgData] = await Promise.all([
+  const [postData, bgSrc] = await Promise.all([
     sql`SELECT "targetNickname", platform, "etcPlatformName" FROM "Post" WHERE id = ${postId};`,
-    readFile(join(process.cwd(), "public", "patda_og.jpg")),
+    fetch(new URL("patda_og.jpg", process.env.PATDA_PROJECT_URL)).then((res) =>
+      res.arrayBuffer()
+    ),
   ]);
 
-  const bgSrc = Uint8Array.from(bgData).buffer;
   const { targetNickname, platform, etcPlatformName } = postData
     .rows[0] as Pick<
     Database["Post"],


### PR DESCRIPTION
# 구현 내용
- dynamic route로 생성되는 post/[id] 파일의 og-image에서 readFile을 위해 사용하는 `process.cwd()`가 서버 환경에서 local과는 다른 경로를 가리키는 현상.
- `fetch` 및 환경변수로 대체하여 기능하도록 수정

# 이슈 번호
- close #85 