### PR TITLE
프로필 닉네임 이름 대체

### DIFF
--- a/app/lib/database/comments.ts
+++ b/app/lib/database/comments.ts
@@ -21,10 +21,14 @@ export const getComments = cache((postId: number) =>
   db
     .selectFrom("Comment")
     .innerJoin("User", "User.id", "Comment.userId")
+    .leftJoin("Profile", "Profile.userId", "Comment.userId")
     .select([
       "Comment.id as id",
       "User.id as userId",
-      "User.name as userName",
+      "Profile.daangnNickname as daangnNickname",
+      "Profile.bunjangNickname as bunjangNickname",
+      "Profile.joongnaNickname as joongnaNickname",
+      "Profile.etcNickname as etcNickname",
       "images",
       "content",
       "status",
@@ -42,7 +46,6 @@ export const getComment = cache((id: string) =>
     .select([
       "Comment.id as id",
       "User.id as userId",
-      "User.name as userName",
       "images",
       "content",
       "status",

--- a/app/lib/providers/CommentProvider.tsx
+++ b/app/lib/providers/CommentProvider.tsx
@@ -4,11 +4,31 @@ import { createContext, type PropsWithChildren, useContext } from "react";
 
 import type { CommentInfo } from "#lib/types/response.js";
 
-interface CommentValue extends Omit<CommentInfo, "userId"> {}
+interface CommentValue
+  extends Omit<
+    CommentInfo,
+    | "userId"
+    | "daangnNickname"
+    | "bunjangNickname"
+    | "joongnaNickname"
+    | "etcNickname"
+  > {
+  nickname: string | null;
+}
 
 const CommentContext = createContext<CommentValue | null>(null);
 
-interface CommentProviderProps extends Omit<CommentInfo, "userId"> {}
+interface CommentProviderProps
+  extends Omit<
+    CommentInfo,
+    | "userId"
+    | "daangnNickname"
+    | "bunjangNickname"
+    | "joongnaNickname"
+    | "etcNickname"
+  > {
+  nickname: string | null;
+}
 
 export const CommentProvider = ({
   children,

--- a/app/lib/utils/user.ts
+++ b/app/lib/utils/user.ts
@@ -1,5 +1,8 @@
 import type { Session } from "next-auth";
 
+import type { ProfileData } from "#lib/database/users.js";
+import type { Platform } from "#lib/types/property.js";
+
 export function getUserKey(session: Session) {
   const userNameKey = encodeURIComponent(session.user?.name ?? "").replace(
     /[^a-zA-Z0-9]/g,
@@ -8,4 +11,37 @@ export function getUserKey(session: Session) {
   const userId = session.user?.id ?? "";
 
   return `${userNameKey}${userId.slice(0, 5)}`;
+}
+
+export function parsePlatformUserInfo(
+  platform: Platform,
+  profile?: Omit<ProfileData, "userId">
+) {
+  let nickname = "";
+  let additionalInfo = "";
+  let etcPlatformName: string | undefined;
+
+  if (profile) {
+    switch (platform) {
+      case "daangn":
+        nickname = profile.daangnNickname ?? "";
+        additionalInfo = profile.daangnInfo ?? "";
+        break;
+      case "bunjang":
+        nickname = profile.bunjangNickname ?? "";
+        additionalInfo = profile.bunjangInfo ?? "";
+        break;
+      case "joongna":
+        nickname = profile.joongnaNickname ?? "";
+        additionalInfo = profile.joongnaInfo ?? "";
+        break;
+      default:
+        nickname = profile.etcNickname ?? "";
+        additionalInfo = profile.etcInfo ?? "";
+        etcPlatformName = profile.etcPlatformName ?? "";
+        break;
+    }
+  }
+
+  return { nickname, additionalInfo, etcPlatformName };
 }

--- a/app/post/[id]/(author)/AuthorContainer.tsx
+++ b/app/post/[id]/(author)/AuthorContainer.tsx
@@ -1,6 +1,7 @@
 import { PLATFORM_COLOR } from "#lib/constants/platform.js";
 import { getPost } from "#lib/database/posts";
-import { getUser } from "#lib/database/users.js";
+import { getProfile } from "#lib/database/users.js";
+import { parsePlatformUserInfo } from "#lib/utils/user.js";
 import AuthorTag from "#ui/AuthorTag/AuthorTag.jsx";
 import CommentLine from "#ui/SIdeLine/CommentLine.jsx";
 
@@ -13,13 +14,14 @@ export default async function AuthorContainer({
 }: AuthorContainerProps) {
   const { userId, platform, createdAt } = await getPost(postId);
 
-  const userNickname = (await getUser(userId)).name;
+  const profile = await getProfile(userId);
+  const { nickname } = parsePlatformUserInfo(platform, profile);
 
   return (
     <div className="flex">
       <CommentLine bottomDotSize="md" data-comment-line-end />
       <AuthorTag
-        name={userNickname ?? ""}
+        name={nickname ?? "익명의 유저"}
         color={PLATFORM_COLOR[platform]}
         date={createdAt}
         className="mr-3 h-24 grow sm:px-4"

--- a/app/post/[id]/(comment)/_component/CommentItem/CommentHeader.tsx
+++ b/app/post/[id]/(comment)/_component/CommentItem/CommentHeader.tsx
@@ -18,7 +18,7 @@ export default function CommentHeader({
   updateClicked,
   onUpdateClick,
 }: CommentHeaderProps) {
-  const { id, userName, status, createdAt } = useCommentContext();
+  const { id, nickname, status, createdAt } = useCommentContext();
 
   const [deleteState, deleteFormAction] = useDeleteAction(
     deleteCommentAction.bind(null, id)
@@ -33,7 +33,7 @@ export default function CommentHeader({
           "ml-1 font-bold",
           isDebate ? "text-rose-600" : "text-lime-600"
         )}>
-        {userName}
+        {nickname || "익명의 유저"}
       </h3>
       <div className="flex max-2xs:flex-col-reverse max-2xs:gap-1">
         {isMine && (

--- a/app/post/[id]/(comment)/_component/CommentList.tsx
+++ b/app/post/[id]/(comment)/_component/CommentList.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps } from "react";
 import CommentItem from "#app/post/[id]/(comment)/_component/CommentItem/CommentItem.jsx";
 import { auth } from "#auth";
 import { getComments } from "#lib/database/comments.js";
+import { getPost } from "#lib/database/posts";
 import { CommentProvider } from "#lib/providers/CommentProvider.jsx";
 import Dot from "#ui/Dot/Dot.jsx";
 
@@ -17,6 +18,7 @@ export default async function CommentList({
 }: CommentListProps) {
   const comments = await getComments(postId);
   const session = await auth();
+  const { platform } = await getPost(postId);
 
   const commentCount = comments.reduce(
     (acc, cur) => (cur.status === "normal" ? acc + 1 : acc),
@@ -32,14 +34,44 @@ export default async function CommentList({
         <p className="text-lg text-rose-700">{debateCount}개의 반박</p>
       </div>
       <ul className="my-3 mr-3">
-        {comments.map(({ id, userId, ...commentInfo }, idx) => (
-          <CommentProvider key={id} id={id} {...commentInfo}>
-            <CommentItem
-              isMine={userId === session?.user?.id}
-              isLast={idx === comments.length - 1}
-            />
-          </CommentProvider>
-        ))}
+        {comments.map(
+          (
+            {
+              id,
+              userId,
+              daangnNickname,
+              bunjangNickname,
+              joongnaNickname,
+              etcNickname,
+              ...commentInfo
+            },
+            idx
+          ) => {
+            let nickname: string | null = null;
+            if (platform === "daangn") {
+              nickname = daangnNickname;
+            } else if (platform === "bunjang") {
+              nickname = bunjangNickname;
+            } else if (platform === "joongna") {
+              nickname = joongnaNickname;
+            } else if (platform === "etc") {
+              nickname = etcNickname;
+            }
+
+            return (
+              <CommentProvider
+                key={id}
+                id={id}
+                nickname={nickname}
+                {...commentInfo}>
+                <CommentItem
+                  isMine={userId === session?.user?.id}
+                  isLast={idx === comments.length - 1}
+                />
+              </CommentProvider>
+            );
+          }
+        )}
       </ul>
     </section>
   );

--- a/app/post/[id]/_components/PostProfileForm/PostProfileForm.tsx
+++ b/app/post/[id]/_components/PostProfileForm/PostProfileForm.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Fieldset } from "@headlessui/react";
+import { useCallback, useState } from "react";
+
+import ProfileForm from "#app/profile/(platform)/_component/ProfileForm.jsx";
+import { PLATFORM_COLOR } from "#lib/constants/platform.js";
+import type { ProfileData } from "#lib/database/users.js";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import { parsePlatformUserInfo } from "#lib/utils/user.js";
+import Logo from "#public/당근빳다.svg";
+import Legend from "#ui/formItems/Legend.jsx";
+import HelpCircle from "#ui/HelpCircle/HelpCircle.jsx";
+
+interface PostProfileFormProps {
+  profile?: Omit<ProfileData, "userId">;
+}
+
+export default function PostProfileForm({ profile }: PostProfileFormProps) {
+  const platform = usePlatformStore((store) => store.platform);
+  const { nickname, additionalInfo, etcPlatformName } = parsePlatformUserInfo(
+    platform,
+    profile
+  );
+
+  const [isTarget, setIsTarget] = useState(!nickname);
+  const onSuccess = useCallback(() => {
+    setIsTarget(false);
+  }, []);
+
+  const color = PLATFORM_COLOR[platform];
+
+  return (
+    <>
+      <Fieldset className="mt-12 flex w-full min-w-80 max-w-3xl justify-between px-3 md:w-5/6">
+        <Legend colorStyle={color} className="group flex h-12 break-keep">
+          본인 닉네임
+          <Logo className="ml-1 size-8 origin-[25%_75%] group-hover:animate-swing" />
+        </Legend>
+        <HelpCircle className="mt-1">
+          작성자 본인도 닉네임을 표시하면 글의 신뢰도를 높일 수 있습니다.
+        </HelpCircle>
+      </Fieldset>
+      <ProfileForm
+        isTarget={isTarget}
+        platform={platform}
+        nickname={nickname}
+        additionalInfo={additionalInfo}
+        etcPlatformName={etcPlatformName}
+        onSuccess={onSuccess}
+        onEdit={() => setIsTarget(true)}
+        className="flex w-full min-w-80 max-w-3xl justify-between gap-6 px-3 md:w-5/6"
+      />
+    </>
+  );
+}

--- a/app/post/create/page.tsx
+++ b/app/post/create/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
+import PostProfileForm from "#app/post/[id]/_components/PostProfileForm/PostProfileForm.jsx";
 import PostForm from "#app/post/create/form.jsx";
 import { auth } from "#auth";
+import { getProfile } from "#lib/database/users.js";
 import { getImagePath } from "#lib/utils/supabase/imagePath.js";
 
 export const metadata: Metadata = {
@@ -11,12 +13,20 @@ export const metadata: Metadata = {
 
 async function PostCreatePage() {
   const session = await auth();
+  const userId = session?.user?.id;
 
-  if (!session) {
+  if (!userId) {
     redirect("/");
   }
 
-  return <PostForm imagePath={getImagePath({ session })} />;
+  const profile = await getProfile(userId);
+
+  return (
+    <>
+      <PostForm imagePath={getImagePath({ session })} />
+      <PostProfileForm profile={profile} />
+    </>
+  );
 }
 
 export default PostCreatePage;

--- a/app/profile/(platform)/PlatformProfiles.tsx
+++ b/app/profile/(platform)/PlatformProfiles.tsx
@@ -43,7 +43,7 @@ export default function PlatformProfiles({ profile }: PlatformProfilesProp) {
           프로필
           <Logo className="ml-1 size-8 origin-[25%_75%] group-hover:animate-swing" />
         </h1>
-        <HelpCircle className="z-10 mx-2 mt-2">
+        <HelpCircle className="mx-2 mt-2">
           작성한 정보는 나를 저격한 게시글을 찾는데 사용됩니다.
         </HelpCircle>
       </div>

--- a/app/profile/(platform)/PlatformProfiles.tsx
+++ b/app/profile/(platform)/PlatformProfiles.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@headlessui/react";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import ProfileForm from "#app/profile/(platform)/_component/ProfileForm.jsx";
 import {
@@ -9,8 +9,9 @@ import {
   PLATFORM_ID,
   PLATFORM_NAME,
 } from "#lib/constants/platform.js";
-import type { Database } from "#lib/database/db.js";
+import type { ProfileData } from "#lib/database/users.js";
 import type { Platform } from "#lib/types/property.js";
+import { parsePlatformUserInfo } from "#lib/utils/user.js";
 import Logo from "#public/당근빳다.svg";
 import { labelVariants } from "#ui/formItems/Label.jsx";
 import HelpCircle from "#ui/HelpCircle/HelpCircle.jsx";
@@ -20,12 +21,16 @@ import { cn } from "#utils/utils.js";
 const PLATFORMS = [...Object.values(PLATFORM_ID)];
 
 interface PlatformProfilesProp {
-  profile?: Omit<Database["Profile"], "userId">;
+  profile?: Omit<ProfileData, "userId">;
 }
 
 export default function PlatformProfiles({ profile }: PlatformProfilesProp) {
   const [targetPlatform, setTargetPlatform] = useState<Platform | null>(null);
   const colorStyle = PLATFORM_COLOR[targetPlatform || "daangn"];
+
+  const onSuccess = useCallback(() => {
+    setTargetPlatform(null);
+  }, []);
 
   return (
     <section>
@@ -45,7 +50,7 @@ export default function PlatformProfiles({ profile }: PlatformProfilesProp) {
       {PLATFORMS.map((platform) => {
         const isTarget = targetPlatform === platform;
 
-        const [nickname, additionalInfo, etcPlatformName] =
+        const { nickname, additionalInfo, etcPlatformName } =
           parsePlatformUserInfo(platform, profile);
 
         return (
@@ -53,10 +58,11 @@ export default function PlatformProfiles({ profile }: PlatformProfilesProp) {
             key={platform}
             platform={platform}
             isTarget={isTarget}
-            setTargetPlatform={setTargetPlatform}
             nickname={nickname}
             additionalInfo={additionalInfo}
             etcPlatformName={etcPlatformName}
+            onSuccess={onSuccess}
+            onEdit={() => setTargetPlatform(platform)}
             className="flex items-center gap-6">
             <Button
               type="button"
@@ -75,37 +81,4 @@ export default function PlatformProfiles({ profile }: PlatformProfilesProp) {
       })}
     </section>
   );
-}
-
-function parsePlatformUserInfo(
-  platform: Platform,
-  profile: PlatformProfilesProp["profile"]
-): [string, string, string | undefined] {
-  let nickname = "";
-  let additionalInfo = "";
-  let etcPlatformName: string | undefined;
-
-  if (profile) {
-    switch (platform) {
-      case "daangn":
-        nickname = profile.daangnNickname ?? "";
-        additionalInfo = profile.daangnInfo ?? "";
-        break;
-      case "bunjang":
-        nickname = profile.bunjangNickname ?? "";
-        additionalInfo = profile.bunjangInfo ?? "";
-        break;
-      case "joongna":
-        nickname = profile.joongnaNickname ?? "";
-        additionalInfo = profile.joongnaInfo ?? "";
-        break;
-      default:
-        nickname = profile.etcNickname ?? "";
-        additionalInfo = profile.etcInfo ?? "";
-        etcPlatformName = profile.etcPlatformName ?? "";
-        break;
-    }
-  }
-
-  return [nickname, additionalInfo, etcPlatformName];
 }

--- a/app/profile/(platform)/_component/ProfileForm.tsx
+++ b/app/profile/(platform)/_component/ProfileForm.tsx
@@ -21,30 +21,32 @@ import EditButton from "#ui/Button/EditButton.jsx";
 interface ProfileFormProp extends ComponentProps<"form"> {
   platform: Platform;
   isTarget: boolean;
-  setTargetPlatform: Dispatch<SetStateAction<Platform | null>>;
   nickname: string;
   additionalInfo: string;
   etcPlatformName?: string;
+  onSuccess?: () => void;
+  onEdit?: () => void;
 }
 
 export default function ProfileForm({
   platform,
   isTarget,
-  setTargetPlatform,
   nickname,
   additionalInfo,
   etcPlatformName,
+  onSuccess,
+  onEdit,
   className,
   children,
   ...props
 }: PropsWithChildren<ProfileFormProp>) {
   const router = useRouter();
 
-  const onSuccess = useCallback(() => {
-    setTargetPlatform(null);
+  const handleSuccess = useCallback(() => {
+    onSuccess?.();
 
     router.refresh();
-  }, [router, setTargetPlatform]);
+  }, [router, onSuccess]);
 
   const {
     register,
@@ -52,13 +54,13 @@ export default function ProfileForm({
     formAction,
   } = useFormAction<ProfileFormValues>({
     action: upsertProfileAction.bind(null, platform),
-    onSuccess,
+    onSuccess: handleSuccess,
   });
 
   const handleEditClick = () => {
     if (isTarget) return;
 
-    setTargetPlatform(platform);
+    onEdit?.();
   };
 
   return (

--- a/app/ui/Header/Profile/ProfileDropdown.tsx
+++ b/app/ui/Header/Profile/ProfileDropdown.tsx
@@ -1,30 +1,30 @@
 import { MenuHeading, MenuItems, MenuSection } from "@headlessui/react";
 import { BiDoorOpen } from "@react-icons/all-files/bi/BiDoorOpen";
 import Link from "next/link";
-import { Session } from "next-auth";
 import { forwardRef } from "react";
 
 import { providerMap } from "#auth";
+import type { ProfileData } from "#lib/database/users.js";
 import MenuItemButton from "#ui/Header/Profile/MenuItemButton.jsx";
+import ProfileHeading from "#ui/Header/Profile/ProfileHeading.jsx";
 import SignButton from "#ui/Header/Profile/SignButton.jsx";
 
 interface ProfileDropdownProps {
-  session: Session | null;
+  isLogin: boolean;
+  profileData?: Omit<ProfileData, "userId">;
 }
 
 const ProfileDropdown = forwardRef<HTMLDivElement, ProfileDropdownProps>(
-  ({ session, ...props }, ref) => {
+  ({ isLogin, profileData, ...props }, ref) => {
     return (
       <MenuItems
         anchor={{ to: "bottom", gap: "16px", padding: "12px" }}
         className="w-96 origin-top rounded-l-lg rounded-br-lg bg-white/70 p-3 shadow-lg backdrop-blur transition"
         ref={ref}
         {...props}>
-        {session?.user ? (
+        {isLogin ? (
           <MenuSection>
-            <MenuHeading className="mb-2 text-sm opacity-50">
-              {session.user.name} 님
-            </MenuHeading>
+            <ProfileHeading profileData={profileData} />
             <Link href="/profile">
               <MenuItemButton>
                 <BiDoorOpen className={`mr-3 size-6 fill-gray-700`} />

--- a/app/ui/Header/Profile/ProfileHeading.tsx
+++ b/app/ui/Header/Profile/ProfileHeading.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { MenuHeading } from "@headlessui/react";
+
+import type { ProfileData } from "#lib/database/users.js";
+import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
+import type { Platform } from "#lib/types/property.js";
+
+interface ProfileHeadingProps {
+  profileData?: Omit<ProfileData, "userId">;
+}
+
+export default function ProfileHeading({ profileData }: ProfileHeadingProps) {
+  const platform = usePlatformStore((store) => store.platform);
+  const userNickname = profileData
+    ? getUserNickname(profileData, platform)
+    : null;
+
+  return (
+    <MenuHeading className="mb-2 text-sm opacity-50">
+      {userNickname
+        ? `${userNickname} 님`
+        : "마이페이지에서 닉네임을 설정해주세요"}
+    </MenuHeading>
+  );
+}
+
+function getUserNickname(
+  profileData: Omit<ProfileData, "userId">,
+  platform: Platform
+) {
+  switch (platform) {
+    case "daangn":
+      return profileData.daangnNickname;
+    case "bunjang":
+      return profileData.bunjangNickname;
+    case "joongna":
+      return profileData.joongnaNickname;
+    case "etc":
+      return profileData.etcNickname;
+  }
+}

--- a/app/ui/Header/Profile/ProfileHeading.tsx
+++ b/app/ui/Header/Profile/ProfileHeading.tsx
@@ -4,7 +4,7 @@ import { MenuHeading } from "@headlessui/react";
 
 import type { ProfileData } from "#lib/database/users.js";
 import { usePlatformStore } from "#lib/providers/PlatformStoreProvider.jsx";
-import type { Platform } from "#lib/types/property.js";
+import { parsePlatformUserInfo } from "#lib/utils/user.js";
 
 interface ProfileHeadingProps {
   profileData?: Omit<ProfileData, "userId">;
@@ -13,7 +13,7 @@ interface ProfileHeadingProps {
 export default function ProfileHeading({ profileData }: ProfileHeadingProps) {
   const platform = usePlatformStore((store) => store.platform);
   const userNickname = profileData
-    ? getUserNickname(profileData, platform)
+    ? parsePlatformUserInfo(platform, profileData).nickname
     : null;
 
   return (
@@ -23,20 +23,4 @@ export default function ProfileHeading({ profileData }: ProfileHeadingProps) {
         : "마이페이지에서 닉네임을 설정해주세요"}
     </MenuHeading>
   );
-}
-
-function getUserNickname(
-  profileData: Omit<ProfileData, "userId">,
-  platform: Platform
-) {
-  switch (platform) {
-    case "daangn":
-      return profileData.daangnNickname;
-    case "bunjang":
-      return profileData.bunjangNickname;
-    case "joongna":
-      return profileData.joongnaNickname;
-    case "etc":
-      return profileData.etcNickname;
-  }
 }

--- a/app/ui/Header/Profile/ProfileMenu.tsx
+++ b/app/ui/Header/Profile/ProfileMenu.tsx
@@ -1,11 +1,18 @@
 import { Menu, Transition } from "@headlessui/react";
 
 import { auth } from "#auth";
+import { getProfile, type ProfileData } from "#lib/database/users.js";
 import ProfileDropdown from "#ui/Header/Profile/ProfileDropdown.jsx";
 import ProfileMenuButton from "#ui/Header/Profile/ProfileMenuButton.jsx";
 
-async function ProfileMenu() {
+export default async function ProfileMenu() {
   const session = await auth();
+  const userId = session?.user?.id;
+
+  let profileData: Omit<ProfileData, "userId"> | undefined;
+  if (userId) {
+    profileData = await getProfile(userId);
+  }
 
   return (
     <Menu>
@@ -17,10 +24,8 @@ async function ProfileMenu() {
         leave="duration-300 ease-out"
         leaveFrom="scale-100 opacity-100"
         leaveTo="scale-95 opacity-0">
-        <ProfileDropdown session={session} />
+        <ProfileDropdown isLogin={!!session} profileData={profileData} />
       </Transition>
     </Menu>
   );
 }
-
-export default ProfileMenu;

--- a/app/ui/Header/Profile/ProfileMenu.tsx
+++ b/app/ui/Header/Profile/ProfileMenu.tsx
@@ -16,7 +16,7 @@ export default async function ProfileMenu() {
 
   return (
     <Menu>
-      <ProfileMenuButton isLogin={!!session} />
+      <ProfileMenuButton isLogin={!!session} profileData={profileData} />
       <Transition
         enter="duration-200 ease-out"
         enterFrom="scale-95 opacity-0"

--- a/app/ui/Header/Profile/ProfileMenuButton.tsx
+++ b/app/ui/Header/Profile/ProfileMenuButton.tsx
@@ -1,22 +1,64 @@
 "use client";
 
 import { MenuButton } from "@headlessui/react";
+import { FiMoreHorizontal } from "@react-icons/all-files/fi/FiMoreHorizontal";
 import { IoPersonCircleOutline } from "@react-icons/all-files/io5/IoPersonCircleOutline";
+import { cva, type VariantProps } from "class-variance-authority";
 
+import type { ProfileData } from "#lib/database/users.js";
 import { useProfileRef } from "#lib/providers/ProfileRefProvider.jsx";
+import DaangnLogo from "#public/당근.svg";
+import BunjangLogo from "#public/번개장터.svg";
+import JoongnaLogo from "#public/중고나라.svg";
+import { cn } from "#utils/utils.js";
+
+const menuButtonVariants = cva("size-12 shrink-0 rounded-full border-2", {
+  variants: {
+    theme: {
+      none: "",
+      daangn: "border-orange-500 bg-orange-100",
+      bunjang: "border-red-500 bg-red-100",
+      joongna: "border-green-500 bg-green-100",
+      etc: "border-zinc-500 bg-zinc-100",
+    },
+  },
+  defaultVariants: {
+    theme: "none",
+  },
+});
 
 interface ProfileMenuButtonProps {
   isLogin: boolean;
+  profileData?: Omit<ProfileData, "userId">;
 }
 
-function ProfileMenuButton({ isLogin }: ProfileMenuButtonProps) {
+export default function ProfileMenuButton({
+  isLogin,
+  profileData,
+}: ProfileMenuButtonProps) {
   const profileRef = useProfileRef();
 
+  let MenuIcon = <IoPersonCircleOutline className="size-full" />;
+  let theme: VariantProps<typeof menuButtonVariants>["theme"] = "none";
+  if (isLogin) {
+    if (profileData?.daangnNickname) {
+      MenuIcon = <DaangnLogo className="size-full" />;
+      theme = "daangn";
+    } else if (profileData?.bunjangNickname) {
+      MenuIcon = <BunjangLogo className="size-full" />;
+      theme = "bunjang";
+    } else if (profileData?.joongnaNickname) {
+      MenuIcon = <JoongnaLogo className="size-full" />;
+      theme = "joongna";
+    } else {
+      MenuIcon = <FiMoreHorizontal className="size-full" />;
+      theme = "etc";
+    }
+  }
+
   return (
-    <MenuButton className={`size-12 shrink-0 rounded-full`} ref={profileRef}>
-      <IoPersonCircleOutline className="size-full" />
+    <MenuButton className={cn(menuButtonVariants({ theme }))} ref={profileRef}>
+      {MenuIcon}
     </MenuButton>
   );
 }
-
-export default ProfileMenuButton;

--- a/app/ui/HelpCircle/HelpCircle.tsx
+++ b/app/ui/HelpCircle/HelpCircle.tsx
@@ -82,7 +82,7 @@ const HelpCircle = ({
       <div
         ref={boxRef}
         className={cn(
-          "absolute w-48 break-words rounded-md bg-neutral-100 p-3 text-sm shadow",
+          "absolute w-48 break-words rounded-md bg-neutral-100 p-3 text-sm shadow z-10",
           boxPositionYStyle,
           boxPositionXStyle[xPosition],
           visibilityStyle

--- a/stories/CommentItem.stories.tsx
+++ b/stories/CommentItem.stories.tsx
@@ -16,7 +16,10 @@ import type { CommentInfo } from "#lib/types/response.js";
 const dummyComment: CommentInfo = {
   id: "1",
   userId: "1",
-  userName: "user123",
+  daangnNickname: "dd",
+  bunjangNickname: "bb",
+  joongnaNickname: "jj",
+  etcNickname: "ee",
   /** content.length >= 3000  */
   content:
     "Amidst the azure twilight, a curious squirrel serenaded the moon with a harmonica made of stardust. The celestial melody echoed through the ancient forest, captivating the fireflies and enchanting the leaves. Each note carried a secret whispered by the constellations, and the squirrel’s tiny paws danced across the silvered branches as if conducting a cosmic symphony. The moon, a silent audience, bathed the scene in its silvery glow, casting elongated shadows that swayed to the rhythm. And so, under the watchful eyes of the night, the squirrel played on, bridging the realms of earth and sky with its celestial music.\
@@ -36,20 +39,30 @@ const meta = {
   },
   tags: ["autodocs"],
   decorators: [
-    (Story) => (
-      <CommentStatusStoreProvider>
-        <CommentProvider {...dummyComment}>
-          <div
-            style={{
-              width: "100%",
-              maxWidth: "48rem",
-              margin: "10% auto 10% auto",
-            }}>
-            {Story()}
-          </div>
-        </CommentProvider>
-      </CommentStatusStoreProvider>
-    ),
+    (Story) => {
+      const {
+        daangnNickname,
+        bunjangNickname,
+        joongnaNickname,
+        etcNickname,
+        ...rest
+      } = dummyComment;
+
+      return (
+        <CommentStatusStoreProvider>
+          <CommentProvider nickname={daangnNickname} {...rest}>
+            <div
+              style={{
+                width: "100%",
+                maxWidth: "48rem",
+                margin: "10% auto 10% auto",
+              }}>
+              {Story()}
+            </div>
+          </CommentProvider>
+        </CommentStatusStoreProvider>
+      );
+    },
   ],
   async beforeEach() {
     const mockAuth = new Promise<Session>((resolve) => {


### PR DESCRIPTION
# 구현 내용
- 프로필 드롭다운과 게시글, 댓글에 사용자 실명이 표시되던 점을 수정합니다.
  - 프로필 정보에 저장되는 닉네임으로 대체합니다.
  - 닉네임을 설정하지 않았을 시 "익명의 유저"로 표시합니다.
- 프로필 드롭다운에 로그인 시 닉네임이 설정된 플랫폼 아이콘으로 이미지를 변경합니다.
  - 없을 시 기타 아이콘 기본값.
  - 닉네임 없을 시 프로필 페이지로 유도하는 문구 표시.
- 게시글 작성 폼의 하단에 선택적으로 닉네임을 변경할 수 있도록 프로필 폼을 추가합니다.
  - 기존 프로필 폼을 재사용.
  - 게시글 수정에는 필요성이 적다고 생각하여 미추가.

# 이슈 번호
- close #88 