### PR TITLE
email 필드 not null 조건 제거.

### DIFF
--- a/app/lib/database/db.ts
+++ b/app/lib/database/db.ts
@@ -11,7 +11,7 @@ export interface Database {
   User: {
     id: GeneratedAlways<string>;
     name: string | null;
-    email: string;
+    email: string | null;
     emailVerified: Date | null;
     image: string | null;
   };

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -8,7 +8,7 @@ export async function create() {
       col.primaryKey().defaultTo(sql`gen_random_uuid()`)
     )
     .addColumn("name", "text")
-    .addColumn("email", "text", (col) => col.unique().notNull())
+    .addColumn("email", "text", (col) => col.unique())
     .addColumn("emailVerified", "timestamptz")
     .addColumn("image", "text")
     .execute();


### PR DESCRIPTION
# 구현 내용
- 서비스에서 요구하는 정보가 없었지만 User 테이블의 email 필드가 not null로 설정되어 있어 소셜 로그인 시 오류가 발생했습니다.
- 조건을 제거하여 처리합니다.

# 이슈 번호
- close #91 